### PR TITLE
Fix Symfony 8 upgrade deprecations

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -18,8 +18,6 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Entity'
                 prefix: 'App\Entity'
                 alias: App
-        controller_resolver:
-            auto_mapping: false
 
 when@test:
     doctrine:

--- a/src/Form/LoginFormType.php
+++ b/src/Form/LoginFormType.php
@@ -19,18 +19,14 @@ class LoginFormType extends AbstractType
                 'label' => 'form.field.email',
                 'attr' => ['autocomplete' => 'email'],
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'Please enter an email.'
-                    ]),
+                    new NotBlank(message: 'Please enter an email.'),
                 ],
             ])
             ->add('password', PasswordType::class, [
                 'label' => 'form.field.password',
                 'attr' => ['autocomplete' => 'current-password'],
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'Please enter a password.'
-                    ]),
+                    new NotBlank(message: 'Please enter a password.'),
                 ],
             ])
             ->add('remember_me', CheckboxType::class, [

--- a/src/Form/RegistrationFormType.php
+++ b/src/Form/RegistrationFormType.php
@@ -23,17 +23,13 @@ class RegistrationFormType extends AbstractType
                 'label' => 'form.field.firstname',
                 'attr' => ['autofocus' => true],
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'Please enter a firstname'
-                    ]),
+                    new NotBlank(message: 'Please enter a firstname'),
                 ],
             ])
             ->add('lastname', TextType::class, [
                 'label' => 'form.field.lastname',
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'Please enter a lastname'
-                    ]),
+                    new NotBlank(message: 'Please enter a lastname'),
                 ],
             ])
             ->add('email', EmailType::class, ['label' => 'form.field.email'])
@@ -52,9 +48,7 @@ class RegistrationFormType extends AbstractType
                 'mapped' => false,
                 'attr' => ['autocomplete' => 'new-password'],
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'Please enter a password.',
-                    ]),
+                    new NotBlank(message: 'Please enter a password.'),
                     new Length([
                         'min' => 6,
                         'minMessage' => 'Your password should be at least {{ limit }} characters.',

--- a/src/Security/Voter/PersonVoter.php
+++ b/src/Security/Voter/PersonVoter.php
@@ -5,6 +5,7 @@ namespace App\Security\Voter;
 use App\Entity\Person;
 use App\Entity\User;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -20,7 +21,7 @@ class PersonVoter extends Voter
             && $subject instanceof \App\Entity\Person;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         $user = $token->getUser();
         // if the user is anonymous, do not grant access
@@ -34,16 +35,15 @@ class PersonVoter extends Voter
         switch ($attribute) {
             case self::EDIT:
                 return $this->canEdit($person, $user);
-                break;
 
             case self::VIEW:
                 return $this->canView($person, $user);
-                break;
 
             case self::DELETE:
                 return $this->canDelete($person, $user);
-                break;
         }
+
+        return false;
     }
 
     private function isOwner(Person $person, User $user): bool

--- a/src/Security/Voter/TreeVoter.php
+++ b/src/Security/Voter/TreeVoter.php
@@ -5,6 +5,7 @@ namespace App\Security\Voter;
 use App\Entity\Tree;
 use App\Entity\User;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -21,7 +22,7 @@ class TreeVoter extends Voter
             && $subject instanceof \App\Entity\Tree;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         $user = $token->getUser();
         // if the user is anonymous, do not grant access
@@ -35,19 +36,15 @@ class TreeVoter extends Voter
         switch ($attribute) {
             case self::EDIT:
                 return $this->canEdit($tree, $user);
-                break;
 
             case self::VIEW:
                 return $this->canView($tree, $user);
-                break;
 
             case self::DELETE:
                 return $this->canDelete($tree, $user);
-                break;
 
             case self::ADD_MEMBER:
                 return $this->canAddMember($tree, $user);
-                break;
         }
 
         return false;

--- a/src/Security/Voter/UnionVoter.php
+++ b/src/Security/Voter/UnionVoter.php
@@ -5,6 +5,7 @@ namespace App\Security\Voter;
 use App\Entity\Union;
 use App\Entity\User;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -20,7 +21,7 @@ class UnionVoter extends Voter
             && $subject instanceof \App\Entity\Union;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         $user = $token->getUser();
         // if the user is anonymous, do not grant access
@@ -34,16 +35,15 @@ class UnionVoter extends Voter
         switch ($attribute) {
             case self::EDIT:
                 return $this->canEdit($union, $user);
-                break;
 
             case self::VIEW:
                 return $this->canView($union, $user);
-                break;
 
             case self::DELETE:
                 return $this->canDelete($union, $user);
-                break;
         }
+
+        return false;
     }
 
     private function isOwner(Union $union, User $user): bool


### PR DESCRIPTION
## Summary
- update security voters to use the Symfony 8-compatible `Vote` argument signature
- remove deprecated Doctrine controller resolver auto-mapping configuration
- replace array-based `NotBlank` constraint options with named arguments