### PR TITLE
Allow editing source items from member profiles

### DIFF
--- a/.env
+++ b/.env
@@ -37,5 +37,5 @@ MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 ###< symfony/messenger ###
 
 ###> symfony/mailer ###
-# MAILER_DSN=null://null
+MAILER_DSN=null://null
 ###< symfony/mailer ###

--- a/src/Controller/SourceController.php
+++ b/src/Controller/SourceController.php
@@ -11,6 +11,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[Route('/person/{personId}/source')]
@@ -21,13 +22,14 @@ class SourceController extends AbstractController
     ) {}
     
     #[Route('/', name: 'app_source_index', methods: ['GET', 'POST'])]
+    #[IsGranted('edit', 'person')]
     public function index(Request $request, EntityManagerInterface $entityManager, #[MapEntity(id: 'personId')] Person $person): Response
     {
         $source = new Source();
-        $form = $this->createForm(SourceType::class, $source);
-        $form->handleRequest($request);
+        $createForm = $this->createForm(SourceType::class, $source);
+        $createForm->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
+        if ($createForm->isSubmitted() && $createForm->isValid()) {
             $source->setPerson($person);
             $entityManager->persist($source);
             $entityManager->flush();
@@ -42,13 +44,52 @@ class SourceController extends AbstractController
         return $this->render('source/index.html.twig', [
             'sources' => $person->getSources(),
             'person' => $person,
-            'form' => $form,
+            'create_form' => $createForm->createView(),
+            'edit_form' => null,
+            'editing_source' => null,
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'app_source_edit', methods: ['GET', 'POST'])]
+    #[IsGranted('edit', 'person')]
+    public function edit(
+        Request $request,
+        Source $source,
+        EntityManagerInterface $entityManager,
+        #[MapEntity(id: 'personId')] Person $person,
+    ): Response {
+        $this->assertSourceBelongsToPerson($source, $person);
+
+        $createForm = $this->createForm(SourceType::class, new Source());
+        $editForm = $this->createForm(SourceType::class, $source);
+        $editForm->handleRequest($request);
+
+        if ($editForm->isSubmitted() && $editForm->isValid()) {
+            $entityManager->flush();
+
+            $this->addFlash(
+                'success',
+                $this->translator->trans('source.edit.success')
+            );
+
+            return $this->redirectToRoute('app_source_index', ['personId' => $person->getId()], Response::HTTP_SEE_OTHER);
+        }
+
+        return $this->render('source/index.html.twig', [
+            'sources' => $person->getSources(),
+            'person' => $person,
+            'create_form' => $createForm->createView(),
+            'edit_form' => $editForm->createView(),
+            'editing_source' => $source,
         ]);
     }
 
     #[Route('/{id}', name: 'app_source_delete', methods: ['POST'])]
+    #[IsGranted('edit', 'person')]
     public function delete(Request $request, Source $source, EntityManagerInterface $entityManager, #[MapEntity(id: 'personId')] Person $person): Response
     {
+        $this->assertSourceBelongsToPerson($source, $person);
+
         if ($this->isCsrfTokenValid('delete'.$source->getId(), $request->request->get('_token'))) {
             $entityManager->remove($source);
             $entityManager->flush();
@@ -65,5 +106,12 @@ class SourceController extends AbstractController
         }
 
         return $this->redirectToRoute('app_source_index', ['personId' => $person->getId()], Response::HTTP_SEE_OTHER);
+    }
+
+    private function assertSourceBelongsToPerson(Source $source, Person $person): void
+    {
+        if ($source->getPerson()?->getId() !== $person->getId()) {
+            throw $this->createNotFoundException();
+        }
     }
 }

--- a/src/Form/RegistrationFormType.php
+++ b/src/Form/RegistrationFormType.php
@@ -36,9 +36,7 @@ class RegistrationFormType extends AbstractType
             ->add('agreeTerms', CheckboxType::class, [
                 'mapped' => false,
                 'constraints' => [
-                    new IsTrue([
-                        'message' => 'You should agree to our terms.',
-                    ]),
+                    new IsTrue(message: 'You should agree to our terms.'),
                 ],
                 'label' => 'form.field.agreeTerms',
             ])
@@ -49,12 +47,12 @@ class RegistrationFormType extends AbstractType
                 'attr' => ['autocomplete' => 'new-password'],
                 'constraints' => [
                     new NotBlank(message: 'Please enter a password.'),
-                    new Length([
-                        'min' => 6,
-                        'minMessage' => 'Your password should be at least {{ limit }} characters.',
+                    new Length(
+                        min: 6,
+                        minMessage: 'Your password should be at least {{ limit }} characters.',
                         // max length allowed by Symfony for security reasons
-                        'max' => 4096,
-                    ]),
+                        max: 4096,
+                    ),
                 ],
                 'label' => 'form.field.password',
             ])

--- a/src/Form/SourceType.php
+++ b/src/Form/SourceType.php
@@ -32,7 +32,7 @@ class SourceType extends AbstractType
             ->add('comment', null, [
                 'label' => 'form.field.comment',
                 'constraints' => [
-                    new Length(['max' => 255]),
+                    new Length(max: 255),
                 ],
             ])
             ->add('directProof', null, [

--- a/templates/person/base.html.twig
+++ b/templates/person/base.html.twig
@@ -1,6 +1,6 @@
 {% extends "base.html.twig" %}
 {% import "person/_macro.html.twig" as macro %}
-{% set route_name = app.request.get('_route') %}
+{% set route_name = app.request.attributes.get('_route') %}
 
 {% block body %}
     {% block breadcrumb %}{% endblock %}

--- a/templates/source/_form.html.twig
+++ b/templates/source/_form.html.twig
@@ -13,15 +13,15 @@
     {{ form_row(form.directProof) }}
 
     <div class="text-end">
+        {% if cancel_path is defined and cancel_path %}
+            <a href="{{ cancel_path }}" class="btn btn-secondary mb-3">
+                {{ 'action.cancel'|trans }}
+            </a>
+        {% endif %}
+            
         <button class="btn btn-primary mb-3" type="submit">
             <i class="fa-solid {{ button_icon|default('fa-plus') }}"></i>
             {{ button_label|default('action.add'|trans) }}
         </button>
-
-        {% if cancel_path is defined and cancel_path %}
-            <a href="{{ cancel_path }}" class="btn btn-link mb-3">
-                {{ 'action.cancel'|trans }}
-            </a>
-        {% endif %}
     </div>
 {{ form_end(form) }}

--- a/templates/source/_form.html.twig
+++ b/templates/source/_form.html.twig
@@ -14,8 +14,14 @@
 
     <div class="text-end">
         <button class="btn btn-primary mb-3" type="submit">
-            <i class="fa-solid fa-plus"></i>
-            {{ 'action.add'|trans }}
+            <i class="fa-solid {{ button_icon|default('fa-plus') }}"></i>
+            {{ button_label|default('action.add'|trans) }}
         </button>
+
+        {% if cancel_path is defined and cancel_path %}
+            <a href="{{ cancel_path }}" class="btn btn-link mb-3">
+                {{ 'action.cancel'|trans }}
+            </a>
+        {% endif %}
     </div>
 {{ form_end(form) }}

--- a/templates/source/index.html.twig
+++ b/templates/source/index.html.twig
@@ -48,7 +48,7 @@
                         <div class="col-auto ms-auto">
                             <a
                                 href="{{ path('app_source_edit', { id: source.id, personId: person.id }) }}"
-                                class="btn bts-sm btn-link p-0"
+                                class="btn btn-sm btn-link p-0"
                                 title="{{ 'action.edit'|trans }}"
                             >
                                 <i class="fa-solid fa-lg fa-pen-to-square"></i>

--- a/templates/source/index.html.twig
+++ b/templates/source/index.html.twig
@@ -48,10 +48,10 @@
                         <div class="col-auto ms-auto">
                             <a
                                 href="{{ path('app_source_edit', { id: source.id, personId: person.id }) }}"
-                                class="btn btn-sm btn-outline-primary"
+                                class="btn bts-sm btn-link p-0"
+                                title="{{ 'action.edit'|trans }}"
                             >
-                                <i class="fa-solid fa-pen-to-square"></i>
-                                {{ 'action.edit'|trans }}
+                                <i class="fa-solid fa-lg fa-pen-to-square"></i>
                             </a>
                         </div>
 

--- a/templates/source/index.html.twig
+++ b/templates/source/index.html.twig
@@ -11,45 +11,68 @@
 {% endblock %}
 
 {% block content %}
-    {{ include('source/_form.html.twig', {'button_label': 'Update'}) }}
+    {{ include('source/_form.html.twig', {
+        form: create_form,
+        button_label: 'action.add'|trans,
+        button_icon: 'fa-plus'
+    }) }}
 
     <hr>
 
     {% if sources|length > 0 %}
         {% for source in sources %}
             <div class="mb-4">
-                <div class="row g-2 align-items-center">
-                    <div class="col-auto">
-                        <span class="badge rounded-pill text-bg-primary mb-1">
-                            {{ source.types[source.type]|trans }}
-                        </span>
-                    </div>
-
-                    {% if source.isDirectProof %}
+                {% if editing_source and editing_source.id == source.id %}
+                    {{ include('source/_form.html.twig', {
+                        form: edit_form,
+                        button_label: 'action.update'|trans,
+                        button_icon: 'fa-pen-to-square',
+                        cancel_path: path('app_source_index', { personId: person.id })
+                    }) }}
+                {% else %}
+                    <div class="row g-2 align-items-center">
                         <div class="col-auto">
-                            <span title="{{ 'label.direct_proof'|trans }}" data-bs-toggle="tooltip" tabindex="0">
-                                <i class="fa-solid fa-lg fa-badge-check text-primary"></i>
+                            <span class="badge rounded-pill text-bg-primary mb-1">
+                                {{ source.types[source.type]|trans }}
                             </span>
                         </div>
-                    {% endif %}
-                    
-                    <div class="col-auto">
-                        {{ include('source/_delete_form.html.twig', { source: source, person: person }) }}
+
+                        {% if source.isDirectProof %}
+                            <div class="col-auto">
+                                <span title="{{ 'label.direct_proof'|trans }}" data-bs-toggle="tooltip" tabindex="0">
+                                    <i class="fa-solid fa-lg fa-badge-check text-primary"></i>
+                                </span>
+                            </div>
+                        {% endif %}
+
+                        <div class="col-auto ms-auto">
+                            <a
+                                href="{{ path('app_source_edit', { id: source.id, personId: person.id }) }}"
+                                class="btn btn-sm btn-outline-primary"
+                            >
+                                <i class="fa-solid fa-pen-to-square"></i>
+                                {{ 'action.edit'|trans }}
+                            </a>
+                        </div>
+
+                        <div class="col-auto">
+                            {{ include('source/_delete_form.html.twig', { source: source, person: person }) }}
+                        </div>
                     </div>
-                </div>
-                
-                {% if source.comment %}
-                    <div class="text-secondary">
-                        {{ source.comment }}
+
+                    {% if source.comment %}
+                        <div class="text-secondary">
+                            {{ source.comment }}
+                        </div>
+                    {% endif %}
+
+                    <div class="text-truncate">
+                        <a href="{{ source.url }}" target="_blank" class="icon-link">
+                            <i class="fa-solid fa-external-link"></i>
+                            {{ source.url }}
+                        </a>
                     </div>
                 {% endif %}
-                
-                <div class="text-truncate">
-                    <a href="{{ source.url }}" target="_blank" class="icon-link">
-                        <i class="fa-solid fa-external-link"></i>
-                        {{ source.url }}
-                    </a>
-                </div>
             </div>
         {% endfor %}
     {% else %}

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -169,6 +169,14 @@ union:
         remove:
             success: '**{name}** has been successfully removed as a child.'
             error: '**{name}** has not been removed as a child.'
+source:
+    new:
+        success: 'The source has been successfully added.'
+    edit:
+        success: 'The source has been successfully modified.'
+    delete:
+        success: 'The source has been successfully deleted.'
+        error: 'The source has not been deleted.'
 life_line:
     not_all_dated: |
         Not all events were dated, so they could not be automatically

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -173,6 +173,8 @@ union:
 source:
     new:
         success: "La source a bien été ajoutée."
+    edit:
+        success: "La source a bien été modifiée."
     delete:
         success: "La source a bien été supprimée."
         error: "La source n'a pas été supprimée."


### PR DESCRIPTION
## Summary
- add inline editing for person sources, including an edit route, prefilled form state, updated flash messages, and ownership checks on source mutations
- update the source templates so add, edit, cancel, and delete actions work from the same member profile page
- align remaining form constraints and route-name Twig access with current Symfony conventions, and enable the local null mailer DSN

Closes #135