### PR TITLE
Add union end date support

### DIFF
--- a/src/Controller/LifeLineController.php
+++ b/src/Controller/LifeLineController.php
@@ -35,10 +35,10 @@ class LifeLineController extends AbstractController
         // Get union events
         foreach ($person->getUnions() as $union) {
             $hasPartner = $union->getPeople()->count() > 1;
-            $hasUnionDate = !!$union->getWeddingDate();
+            $hasUnionDate = !!$union->getStartsAt();
 
             $events[] = [
-                'date' => $union->getWeddingDate(),
+                'date' => $union->getStartsAt(),
                 'type' => 'union',
                 'label' => $translator->trans('life_line.union.label'),
                 'message' => $translator->trans('life_line.union.message', [
@@ -47,7 +47,7 @@ class LifeLineController extends AbstractController
                     'partner' => $hasPartner ? $union->getPartner($person)->getFullName() : '?',
                     'partner_path' => $hasPartner ? $this->generateUrl('app_person_life_line', ['id' => $union->getPartner($person)->getId()]) : '#',
                     'place' => $union->getWeddingPlace() ?? 'empty',
-                    'year' => $hasUnionDate ? $union->getWeddingDate()->format('Y') : 'empty',
+                    'year' => $hasUnionDate ? $union->getStartsAt()->format('Y') : 'empty',
                 ]),
             ];
 

--- a/src/Entity/Union.php
+++ b/src/Entity/Union.php
@@ -29,11 +29,11 @@ class Union
     #[ORM\Column]
     private ?bool $married = null;
 
-    #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
-    private ?\DateTimeInterface $weddingDate = null;
+    #[ORM\Column(type: Types::DATE_IMMUTABLE, nullable: true)]
+    private ?\DateTimeInterface $startsAt = null;
 
     #[ORM\Column(length: 100, nullable: true)]
-    private ?string $weddingPlace = null;
+    private ?string $place = null;
 
     #[ORM\Column(options: ['default' => false])]
     private ?bool $dayUnsure = null;
@@ -46,6 +46,18 @@ class Union
 
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $description = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $endsAt = null;
+
+    #[ORM\Column(options: ['default' => false])]
+    private ?bool $endDayUnsure = null;
+
+    #[ORM\Column(options: ['default' => false])]
+    private ?bool $endMonthUnsure = null;
+
+    #[ORM\Column(options: ['default' => false])]
+    private ?bool $endYearUnsure = null;
 
     public function __construct()
     {
@@ -129,26 +141,26 @@ class Union
         return $this;
     }
 
-    public function getWeddingDate(): ?\DateTimeInterface
+    public function getStartsAt(): ?\DateTimeImmutable
     {
-        return $this->weddingDate;
+        return $this->startsAt;
     }
 
-    public function setWeddingDate(?\DateTimeInterface $weddingDate): static
+    public function setStartsAt(?\DateTimeImmutable $startsAt): static
     {
-        $this->weddingDate = $weddingDate;
+        $this->startsAt = $startsAt;
 
         return $this;
     }
 
-    public function getWeddingPlace(): ?string
+    public function getPlace(): ?string
     {
-        return $this->formatEmptyString($this->weddingPlace);
+        return $this->formatEmptyString($this->place);
     }
 
-    public function setWeddingPlace(?string $weddingPlace): static
+    public function setPlace(?string $place): static
     {
-        $this->weddingPlace = $weddingPlace;
+        $this->place = $place;
 
         return $this;
     }
@@ -215,5 +227,53 @@ class Union
         }
 
         return null;
+    }
+
+    public function getEndsAt(): ?\DateTimeImmutable
+    {
+        return $this->endsAt;
+    }
+
+    public function setEndsAt(?\DateTimeImmutable $endsAt): static
+    {
+        $this->endsAt = $endsAt;
+
+        return $this;
+    }
+
+    public function isEndDayUnsure(): ?bool
+    {
+        return $this->endDayUnsure;
+    }
+
+    public function setEndDayUnsure(bool $endDayUnsure): static
+    {
+        $this->endDayUnsure = $endDayUnsure;
+
+        return $this;
+    }
+
+    public function isEndMonthUnsure(): ?bool
+    {
+        return $this->endMonthUnsure;
+    }
+
+    public function setEndMonthUnsure(bool $endMonthUnsure): static
+    {
+        $this->endMonthUnsure = $endMonthUnsure;
+
+        return $this;
+    }
+
+    public function isEndYearUnsure(): ?bool
+    {
+        return $this->endYearUnsure;
+    }
+
+    public function setEndYearUnsure(bool $endYearUnsure): static
+    {
+        $this->endYearUnsure = $endYearUnsure;
+
+        return $this;
     }
 }

--- a/src/Form/UnionType.php
+++ b/src/Form/UnionType.php
@@ -21,12 +21,17 @@ class UnionType extends AbstractType
                 'label' => 'form.field.married',
                 'label_attr' => ['class' => 'checkbox-switch'],
             ])
-            ->add('weddingDate', DateType::class, [
+            ->add('startsAt', DateType::class, [
                 'required' => false,
-                'label' => 'form.field.union_date',
+                'label' => 'form.field.union_start_date',
                 'widget' => 'single_text',
             ])
-            ->add('weddingPlace', TextType::class, [
+            ->add('endsAt', DateType::class, [
+                'required' => false,
+                'label' => 'form.field.union_end_date',
+                'widget' => 'single_text',
+            ])
+            ->add('place', TextType::class, [
                 'required' => false,
                 'label' => 'form.field.union_place',
             ])
@@ -51,6 +56,36 @@ class UnionType extends AbstractType
                 ],
             ])
             ->add('yearUnsure', CheckboxType::class, [
+                'required' => false,
+                'label' => 'form.field.uncertain_year',
+                'label_attr' => [
+                    'class' => 'checkbox-inline checkbox-switch'
+                ],
+                'row_attr' => [
+                    'class' => 'd-inline'
+                ],
+            ])
+            ->add('endDayUnsure', CheckboxType::class, [
+                'required' => false,
+                'label' => 'form.field.uncertain_day',
+                'label_attr' => [
+                    'class' => 'checkbox-inline checkbox-switch'
+                ],
+                'row_attr' => [
+                    'class' => 'd-inline'
+                ],
+            ])
+            ->add('endMonthUnsure', CheckboxType::class, [
+                'required' => false,
+                'label' => 'form.field.uncertain_month',
+                'label_attr' => [
+                    'class' => 'checkbox-inline checkbox-switch'
+                ],
+                'row_attr' => [
+                    'class' => 'd-inline'
+                ],
+            ])
+            ->add('endYearUnsure', CheckboxType::class, [
                 'required' => false,
                 'label' => 'form.field.uncertain_year',
                 'label_attr' => [

--- a/templates/union/_form.html.twig
+++ b/templates/union/_form.html.twig
@@ -3,13 +3,13 @@
 
     <div class="row g-2">
         <div class="col-md-6 order-1">
-            {{ form_row(form.weddingDate) }}
+            {{ form_row(form.startsAt) }}
 
         </div>
         <div class="col-md-6 order-3 order-md)2">
-            {{ form_row(form.weddingPlace) }}
+            {{ form_row(form.place) }}
         </div>
-        <div class="col order-2 order-md-3">
+        <div class="col-12 order-2 order-md-3">
             <div class="mb-3">
                 {{ form_row(form.dayUnsure) }}
                 {{ form_row(form.monthUnsure) }}
@@ -19,6 +19,19 @@
     </div>
 
     {{ include('_includes/form/markdown.html.twig', { field: form.description }) }}
+
+    <div class="row g-2">        
+        <div class="col-md-6">
+            {{ form_row(form.endsAt) }}
+        </div>
+        <div class="col-12">
+            <div class="mb-3">
+                {{ form_row(form.endDayUnsure) }}
+                {{ form_row(form.endMonthUnsure) }}
+                {{ form_row(form.endYearUnsure) }}
+            </div>
+        </div>
+    </div>
 
     <div class="text-end">
         <a class="btn btn-secondary" href="{{ path('app_person_unions', { id: person.id }) }}">{{ 'action.cancel'|trans }}</a>

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -32,7 +32,8 @@ form:
         uncertain_day: Uncertain day
         uncertain_month: Uncertain month
         uncertain_year: Uncertain year
-        union_date: Union date
+        union_start_date: Union start date
+        union_end_date: Union end date
         union_place: Union place
         type: Type
         comment: Comment

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -32,7 +32,8 @@ form:
         uncertain_day: Jour incertain
         uncertain_month: Mois incertain
         uncertain_year: Année incertaine
-        union_date: Date de l'union
+        union_start_date: Date de début de l'union
+        union_end_date: Date de fin de l'union
         union_place: Lieu de l'union
         type: Type
         comment: Commentaire


### PR DESCRIPTION
## Summary
- add `startsAt` and `endsAt` union date fields, along with separate uncertainty flags for the end date, so a union can capture both its beginning and ending timeline
- update the union form and translations to expose start/end date labels and inputs in both French and English
- update life line generation to use the renamed union start date field so union events continue to render correctly

## Details
- renamed the persisted union date/place fields to `startsAt` and `place` to match the broader timeline model
- added `endsAt`, `endDayUnsure`, `endMonthUnsure`, and `endYearUnsure` on `App\Entity\Union`
- updated `App\Form\UnionType` and `templates/union/_form.html.twig` to collect both start and end dates plus their uncertainty toggles
- updated `App\Controller\LifeLineController` to read the new union start-date accessor names
- added the new translation keys `form.field.union_start_date` and `form.field.union_end_date`

## Testing
- Not run in this branch

Closes #130