### PR TITLE
Restore feedback after profile updates

### DIFF
--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -68,10 +68,13 @@ class PersonController extends AbstractController
             }
 
             $entityManager->flush();
+            
             $this->addFlash(
                 'success',
                 $this->translator->trans('person.edit.success', ['name' => $person->getFullName()]),
             );
+
+            return $this->redirectToRoute('app_person_show', ['id' => $person->getId()]);
         }
 
         return $this->render('person/edit.html.twig', [


### PR DESCRIPTION
## Summary
- redirect back to the member profile after a successful profile update so Turbo performs a full navigation
- preserve the success flash message by avoiding an in-place render after the POST request
- keep the existing profile update flow unchanged aside from the post-submit redirect

## Testing
- Not run in this branch

Closes #128