### PR TITLE
Improve PHP code quality tooling and automated refactors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@
 
 .DS_Store
 public/pictures
+
+###> friendsofphp/php-cs-fixer ###
+/.php-cs-fixer.php
+/.php-cs-fixer.cache
+###< friendsofphp/php-cs-fixer ###

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,16 @@
+<?php
+
+$finder = (new PhpCsFixer\Finder())
+    ->in([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+;
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@Symfony' => true,
+    ])
+    ->setUnsupportedPhpVersionAllowed(true)
+    ->setFinder($finder)
+;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,31 @@
 # AGENTS.md
 
 ## Stack And Shape
-- Symfony 7.2 app on PHP 8.2+ via Composer; routes are attribute-based from `src/Controller/` (`config/routes.yaml`).
+- Symfony 8.0 app on PHP 8.2+ via Composer; routes are attribute-based from `src/Controller/` (`config/routes.yaml`).
 - Main app flow starts at `/`, which redirects to the authenticated tree area at `/project/` (`src/Controller/HomeController.php`, `src/Controller/TreeController.php`).
 - Core model wiring: `User` owns many `Tree`; each `Person` belongs to one `Tree`; `Union` connects partners and children. Ownership checks are enforced with security voters, not just controller code (`src/Security/Voter/*.php`).
 
 ## Local Dev
-- Install dependencies with `composer install`. There are no Composer shortcuts for test/lint/build.
-- Fast local run: `symfony serve -d`.
+- Run every PHP, Composer, Symfony CLI, and `bin/console` command through Docker with `docker compose exec apache ...`.
+- Install dependencies with `docker compose exec apache composer install`.
 - Docker flow is separate helper tooling: `make init` builds containers, starts them, then runs the in-container Symfony init step; `make up`, `make stop`, `make exec` are the main follow-ups.
 - Important DB gotcha: committed `.env` uses SQLite at `var/data.db`, while `compose.yaml` starts MariaDB + phpMyAdmin but does not wire `DATABASE_URL` for you. If you use Docker DB, set `DATABASE_URL` yourself.
 
 ## Verification And Build
-- PHPUnit config lives in `phpunit.xml.dist`; run focused tests with `php bin/phpunit tests/Controller/TreeControllerTest.php` after `composer install`.
+- PHPUnit config lives in `phpunit.xml.dist`; run focused tests with `docker compose exec apache php bin/phpunit tests/Controller/TreeControllerTest.php` after `docker compose exec apache composer install`.
+- Quality tooling is installed and exposed through Composer scripts:
+  - `docker compose exec apache composer analyse`
+  - `docker compose exec apache composer rector`
+  - `docker compose exec apache composer rector:fix`
+  - `docker compose exec apache composer cs:check`
+  - `docker compose exec apache composer cs:fix`
+  - `docker compose exec apache composer lint`
 - Be careful with the checked-in controller tests before trusting them: they are scaffold leftovers that still target `/tree/` and `/person/`, while current tree routes live under `/project`.
 - Those WebTestCase tests delete repository contents in `setUp()`. Confirm your test database target before running them.
-- Production build order is defined in `.github/workflows/deploy.yml`: `php bin/console sass:build`, `php bin/console asset-map:compile`, `php bin/console assets:install`, then `composer dump-env prod`, optimized autoload, and `php bin/console cache:warmup`.
+- Production build order is defined in `.github/workflows/deploy.yml`: `docker compose exec apache php bin/console sass:build`, `docker compose exec apache php bin/console asset-map:compile`, `docker compose exec apache php bin/console assets:install`, then `docker compose exec apache composer dump-env prod`, optimized autoload, and `docker compose exec apache php bin/console cache:warmup`.
 
 ## Data And Assets
-- After changing Doctrine entities, create and run a migration; README explicitly calls this out, and `src/Command/PostPublishCommand.php` is built around `doctrine:migrations:diff` + `doctrine:migrations:migrate`.
+- After changing Doctrine entities, create and run a migration; README explicitly calls this out, and `src/Command/PostPublishCommand.php` is built around `docker compose exec apache php bin/console doctrine:migrations:diff` + `docker compose exec apache php bin/console doctrine:migrations:migrate`.
 - Frontend assets use AssetMapper + Importmap + SymfonyCasts Sass (`config/packages/asset_mapper.yaml`, `importmap.php`, `assets/app.js`); do not assume Node/Vite.
 - Uploaded portraits are stored in `public/pictures` via `portraits_directory` (`config/services.yaml`, `src/Service/ImageManager.php`). Deploy intentionally excludes `public/pictures/*`, so treat it as persisted user data.
 

--- a/composer.json
+++ b/composer.json
@@ -85,12 +85,22 @@
             "importmap:install": "symfony-cmd",
             "sass:build": "symfony-cmd"
         },
+        "analyse": "php vendor/bin/phpstan analyse --memory-limit=1G",
+        "cs:check": "php vendor/bin/php-cs-fixer fix --dry-run --diff",
+        "cs:fix": "php vendor/bin/php-cs-fixer fix",
         "post-install-cmd": [
             "@auto-scripts"
         ],
         "post-update-cmd": [
             "@auto-scripts"
-        ]
+        ],
+        "lint": [
+            "@analyse",
+            "@rector",
+            "@cs:check"
+        ],
+        "rector": "php vendor/bin/rector process --dry-run",
+        "rector:fix": "php vendor/bin/rector process"
     },
     "conflict": {
         "symfony/symfony": "*"
@@ -103,7 +113,10 @@
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "^4",
+        "friendsofphp/php-cs-fixer": "^3.95",
+        "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^13.1",
+        "rector/rector": "^2.4",
         "symfony/browser-kit": "8.0.*",
         "symfony/css-selector": "8.0.*",
         "symfony/debug-bundle": "8.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "db04f692c133cbf31cf6de22dbd04207",
+    "content-hash": "0f2476e6ef07f7cf3712d00b968bb580",
     "packages": [
         {
             "name": "composer/semver",
@@ -8334,6 +8334,215 @@
     ],
     "packages-dev": [
         {
+            "name": "clue/ndjson-react",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-ndjson.git",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-ndjson/zipball/392dc165fce93b5bb5c637b67e59619223c931b0",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/stream": "^1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
+                "react/event-loop": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\NDJson\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Streaming newline-delimited JSON (NDJSON) parser and encoder for ReactPHP.",
+            "homepage": "https://github.com/clue/reactphp-ndjson",
+            "keywords": [
+                "NDJSON",
+                "json",
+                "jsonlines",
+                "newline",
+                "reactphp",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/reactphp-ndjson/issues",
+                "source": "https://github.com/clue/reactphp-ndjson/tree/v1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-23T10:58:28+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
             "name": "doctrine/data-fixtures",
             "version": "2.2.1",
             "source": {
@@ -8503,6 +8712,288 @@
                 }
             ],
             "time": "2025-12-03T16:05:42+00:00"
+        },
+        {
+            "name": "ergebnis/agent-detector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/agent-detector.git",
+                "reference": "5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/agent-detector/zipball/5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64",
+                "reference": "5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0 || ~8.6.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.50.0",
+                "ergebnis/license": "^2.7.0",
+                "ergebnis/php-cs-fixer-config": "^6.60.2",
+                "ergebnis/phpstan-rules": "^2.13.1",
+                "ergebnis/phpunit-slow-test-detector": "^2.24.0",
+                "ergebnis/rector-rules": "^1.16.0",
+                "fakerphp/faker": "^1.24.1",
+                "infection/infection": "^0.26.6",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.46",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "phpunit/phpunit": "^9.6.34",
+                "rector/rector": "^2.4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0-dev"
+                },
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\AgentDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides a detector for detecting the presence of an agent.",
+            "homepage": "https://github.com/ergebnis/agent-detector",
+            "support": {
+                "issues": "https://github.com/ergebnis/agent-detector/issues",
+                "security": "https://github.com/ergebnis/agent-detector/blob/main/.github/SECURITY.md",
+                "source": "https://github.com/ergebnis/agent-detector"
+            },
+            "time": "2026-04-10T13:45:13+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v3.95.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
+                "reference": "4ba5ab77108583d2a89ed48e1a5c01e62cc1d3f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/4ba5ab77108583d2a89ed48e1a5c01e62cc1d3f4",
+                "reference": "4ba5ab77108583d2a89ed48e1a5c01e62cc1d3f4",
+                "shasum": ""
+            },
+            "require": {
+                "clue/ndjson-react": "^1.3",
+                "composer/semver": "^3.4",
+                "composer/xdebug-handler": "^3.0.5",
+                "ergebnis/agent-detector": "^1.1.1",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "fidry/cpu-core-counter": "^1.3",
+                "php": "^7.4 || ^8.0",
+                "react/child-process": "^0.6.6",
+                "react/event-loop": "^1.5",
+                "react/socket": "^1.16",
+                "react/stream": "^1.4",
+                "sebastian/diff": "^4.0.6 || ^5.1.1 || ^6.0.2 || ^7.0 || ^8.0",
+                "symfony/console": "^5.4.47 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/event-dispatcher": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/filesystem": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/finder": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/options-resolver": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.33",
+                "symfony/polyfill-php80": "^1.33",
+                "symfony/polyfill-php81": "^1.33",
+                "symfony/polyfill-php84": "^1.33",
+                "symfony/process": "^5.4.47 || ^6.4.24 || ^7.2 || ^8.0",
+                "symfony/stopwatch": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "facile-it/paraunit": "^1.3.1 || ^2.8.0",
+                "infection/infection": "^0.32.6",
+                "justinrainbow/json-schema": "^6.8.0",
+                "keradus/cli-executor": "^2.3",
+                "mikey179/vfsstream": "^1.6.12",
+                "php-coveralls/php-coveralls": "^2.9.1",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.8",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.8",
+                "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.55",
+                "symfony/polyfill-php85": "^1.33",
+                "symfony/var-dumper": "^5.4.48 || ^6.4.32 || ^7.4.4 || ^8.0.8",
+                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.8"
+            },
+            "suggest": {
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/**/Internal/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "keywords": [
+                "Static code analysis",
+                "fixer",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-11T17:30:38+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -8739,6 +9230,59 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.46",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
+                "reference": "a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-01T09:25:14+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -9212,6 +9756,592 @@
                 }
             ],
             "time": "2026-04-08T03:07:38+00:00"
+        },
+        {
+            "name": "react/cache",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/cache.git",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/cache/zipball/d47c472b64aa5608225f47965a484b75c7817d5b",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/promise": "^3.0 || ^2.0 || ^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, Promise-based cache interface for ReactPHP",
+            "keywords": [
+                "cache",
+                "caching",
+                "promise",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/cache/issues",
+                "source": "https://github.com/reactphp/cache/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-11-30T15:59:55+00:00"
+        },
+        {
+            "name": "react/child-process",
+            "version": "v0.6.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/child-process.git",
+                "reference": "970f0e71945556422ee4570ccbabaedc3cf04ad3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/child-process/zipball/970f0e71945556422ee4570ccbabaedc3cf04ad3",
+                "reference": "970f0e71945556422ee4570ccbabaedc3cf04ad3",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/event-loop": "^1.2",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/socket": "^1.16",
+                "sebastian/environment": "^5.0 || ^3.0 || ^2.0 || ^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\ChildProcess\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven library for executing child processes with ReactPHP.",
+            "keywords": [
+                "event-driven",
+                "process",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/child-process/issues",
+                "source": "https://github.com/reactphp/child-process/tree/v0.6.7"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-12-23T15:25:20+00:00"
+        },
+        {
+            "name": "react/dns",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/dns.git",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/cache": "^1.0 || ^0.6 || ^0.5",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Dns\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async DNS resolver for ReactPHP",
+            "keywords": [
+                "async",
+                "dns",
+                "dns-resolver",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/dns/issues",
+                "source": "https://github.com/reactphp/dns/tree/v1.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-18T19:34:28+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/event-loop/issues",
+                "source": "https://github.com/reactphp/event-loop/tree/v1.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-17T20:46:25+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-08-19T18:57:03+00:00"
+        },
+        {
+            "name": "react/socket",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/socket.git",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/dns": "^1.13",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3.3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Socket\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server and client connections for ReactPHP",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "async",
+                "reactphp",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/socket/issues",
+                "source": "https://github.com/reactphp/socket/tree/v1.17.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-19T20:47:34+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.2"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/stream/issues",
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-11T12:45:25+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "000b7050b9e4fe98db2192971e56eb0b302b3feb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/000b7050b9e4fe98db2192971e56eb0b302b3feb",
+                "reference": "000b7050b9e4fe98db2192971e56eb0b302b3feb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.1.41"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-08T08:43:56+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,6 @@
+parameters:
+    level: 1
+    paths:
+        - src
+        - tests
+    tmpDir: var/cache/phpstan

--- a/rector.php
+++ b/rector.php
@@ -20,4 +20,5 @@ return RectorConfig::configure()
         strictBooleans: true,
         symfonyCodeQuality: true,
         typeDeclarationDocblocks: true,
+        typeDeclarations: true,
     );

--- a/rector.php
+++ b/rector.php
@@ -18,6 +18,7 @@ return RectorConfig::configure()
         doctrineCodeQuality: true,
         earlyReturn: true,
         instanceOf: true,
+        naming: true,
         privatization: true,
         strictBooleans: true,
         symfonyCodeQuality: true,

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withImportNames()
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+    );

--- a/rector.php
+++ b/rector.php
@@ -16,5 +16,6 @@ return RectorConfig::configure()
         codeQuality: true,
         codingStyle: true,
         doctrineCodeQuality: true,
+        earlyReturn: true,
         symfonyCodeQuality: true,
     );

--- a/rector.php
+++ b/rector.php
@@ -14,6 +14,7 @@ return RectorConfig::configure()
     ->withPreparedSets(
         deadCode: true,
         codeQuality: true,
+        codingStyle: true,
         doctrineCodeQuality: true,
         symfonyCodeQuality: true,
     );

--- a/rector.php
+++ b/rector.php
@@ -17,5 +17,6 @@ return RectorConfig::configure()
         codingStyle: true,
         doctrineCodeQuality: true,
         earlyReturn: true,
+        strictBooleans: true,
         symfonyCodeQuality: true,
     );

--- a/rector.php
+++ b/rector.php
@@ -9,6 +9,7 @@ return RectorConfig::configure()
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
+    ->withAttributesSets(symfony: true)
     ->withPhpSets(php84: true)
     ->withPreparedSets(
         deadCode: true,

--- a/rector.php
+++ b/rector.php
@@ -17,6 +17,7 @@ return RectorConfig::configure()
         codingStyle: true,
         doctrineCodeQuality: true,
         earlyReturn: true,
+        privatization: true,
         strictBooleans: true,
         symfonyCodeQuality: true,
         typeDeclarationDocblocks: true,

--- a/rector.php
+++ b/rector.php
@@ -14,5 +14,6 @@ return RectorConfig::configure()
     ->withPreparedSets(
         deadCode: true,
         codeQuality: true,
+        doctrineCodeQuality: true,
         symfonyCodeQuality: true,
     );

--- a/rector.php
+++ b/rector.php
@@ -19,4 +19,5 @@ return RectorConfig::configure()
         earlyReturn: true,
         strictBooleans: true,
         symfonyCodeQuality: true,
+        typeDeclarationDocblocks: true,
     );

--- a/rector.php
+++ b/rector.php
@@ -9,7 +9,6 @@ return RectorConfig::configure()
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
-    ->withImportNames()
     ->withPreparedSets(
         deadCode: true,
         codeQuality: true,

--- a/rector.php
+++ b/rector.php
@@ -9,6 +9,7 @@ return RectorConfig::configure()
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
+    ->withPhpSets(php84: true)
     ->withPreparedSets(
         deadCode: true,
         codeQuality: true,

--- a/rector.php
+++ b/rector.php
@@ -17,6 +17,7 @@ return RectorConfig::configure()
         codingStyle: true,
         doctrineCodeQuality: true,
         earlyReturn: true,
+        instanceOf: true,
         privatization: true,
         strictBooleans: true,
         symfonyCodeQuality: true,

--- a/rector.php
+++ b/rector.php
@@ -14,4 +14,5 @@ return RectorConfig::configure()
     ->withPreparedSets(
         deadCode: true,
         codeQuality: true,
+        symfonyCodeQuality: true,
     );

--- a/src/Command/PostPublishCommand.php
+++ b/src/Command/PostPublishCommand.php
@@ -38,7 +38,7 @@ class PostPublishCommand extends Command
 
             $io->info('Diff found, applying them');
             $applyDiffCommand->run($applyDiffInput, $output);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $io->info('No diff found');
         }
 

--- a/src/Command/PostPublishCommand.php
+++ b/src/Command/PostPublishCommand.php
@@ -33,6 +33,7 @@ class PostPublishCommand extends Command
         $applyDiffInput->setInteractive(false);
 
         $io->info('Looking for database changes');
+
         try {
             $makeDiffCommand->run($makeDiffInput, $output);
 

--- a/src/Command/PostPublishCommand.php
+++ b/src/Command/PostPublishCommand.php
@@ -16,11 +16,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 class PostPublishCommand extends Command
 {
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
     protected function configure(): void
     {}
 

--- a/src/Command/PostPublishCommand.php
+++ b/src/Command/PostPublishCommand.php
@@ -17,7 +17,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class PostPublishCommand extends Command
 {
     protected function configure(): void
-    {}
+    {
+    }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/src/Command/PostPublishCommand.php
+++ b/src/Command/PostPublishCommand.php
@@ -21,7 +21,7 @@ class PostPublishCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new SymfonyStyle($input, $output);
+        $symfonyStyle = new SymfonyStyle($input, $output);
         $makeDiffCommand = $this->getApplication()->find('doctrine:migrations:diff');
         $makeDiffInput = new ArrayInput(['--allow-empty-diff' => true]);
         $applyDiffCommand = $this->getApplication()->find('doctrine:migrations:migrate');
@@ -31,18 +31,18 @@ class PostPublishCommand extends Command
         $makeDiffInput->setInteractive(false);
         $applyDiffInput->setInteractive(false);
 
-        $io->info('Looking for database changes');
+        $symfonyStyle->info('Looking for database changes');
 
         try {
             $makeDiffCommand->run($makeDiffInput, $output);
 
-            $io->info('Diff found, applying them');
+            $symfonyStyle->info('Diff found, applying them');
             $applyDiffCommand->run($applyDiffInput, $output);
         } catch (\Exception) {
-            $io->info('No diff found');
+            $symfonyStyle->info('No diff found');
         }
 
-        $io->info('Clearing application cache');
+        $symfonyStyle->info('Clearing application cache');
         $clearCacheCommand->run($input, $output);
 
         return Command::SUCCESS;

--- a/src/Command/PostPublishCommand.php
+++ b/src/Command/PostPublishCommand.php
@@ -39,7 +39,7 @@ class PostPublishCommand extends Command
 
             $io->info('Diff found, applying them');
             $applyDiffCommand->run($applyDiffInput, $output);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $io->info('No diff found');
         }
 

--- a/src/Command/PostPublishCommand.php
+++ b/src/Command/PostPublishCommand.php
@@ -2,7 +2,6 @@
 
 namespace App\Command;
 
-use Exception;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/src/Controller/LifeLineController.php
+++ b/src/Controller/LifeLineController.php
@@ -18,7 +18,7 @@ class LifeLineController extends AbstractController
 
         // Get birth event
         if ($person->getBirth() instanceof DateTimeInterface) {
-            $hasBirthDate = !!$person->getBirth();
+            $hasBirthDate = (bool) $person->getBirth();
 
             $events[] = [
                 'date' => $person->getBirth(),
@@ -36,7 +36,7 @@ class LifeLineController extends AbstractController
         // Get union events
         foreach ($person->getUnions() as $union) {
             $hasPartner = $union->getPeople()->count() > 1;
-            $hasUnionDate = !!$union->getStartsAt();
+            $hasUnionDate = (bool) $union->getStartsAt();
 
             $events[] = [
                 'date' => $union->getStartsAt(),
@@ -54,7 +54,7 @@ class LifeLineController extends AbstractController
 
             // Get child events
             foreach ($union->getChildren() as $child) {
-                $hasBirthDate = !!$child->getBirth();
+                $hasBirthDate = (bool) $child->getBirth();
                 $events[] = [
                     'date' => $child->getBirth(),
                     'type' => 'child',
@@ -85,7 +85,7 @@ class LifeLineController extends AbstractController
         }
 
         $allEventsHaveDate = array_reduce($events, function ($carry, $event) {
-            return $carry && !!$event['date'];
+            return $carry && (bool) $event['date'];
         }, true);
 
         if ($allEventsHaveDate) {

--- a/src/Controller/LifeLineController.php
+++ b/src/Controller/LifeLineController.php
@@ -2,7 +2,6 @@
 
 namespace App\Controller;
 
-use DateTimeInterface;
 use App\Entity\Person;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Controller/LifeLineController.php
+++ b/src/Controller/LifeLineController.php
@@ -90,7 +90,7 @@ class LifeLineController extends AbstractController
         $allEventsHaveDate = array_reduce($events, fn ($carry, $event): bool => $carry && (bool) $event['date'], true);
 
         if ($allEventsHaveDate) {
-            usort($events, fn ($a, $b): int => $a['date'] <=> $b['date']);
+            usort($events, fn (array $a, array $b): int => $a['date'] <=> $b['date']);
         }
 
         return $this->render('life_line/index.html.twig', [

--- a/src/Controller/LifeLineController.php
+++ b/src/Controller/LifeLineController.php
@@ -10,7 +10,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class LifeLineController extends AbstractController
 {
-    public function __construct(private readonly \Symfony\Contracts\Translation\TranslatorInterface $translator)
+    public function __construct(private readonly TranslatorInterface $translator)
     {
     }
 

--- a/src/Controller/LifeLineController.php
+++ b/src/Controller/LifeLineController.php
@@ -10,8 +10,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class LifeLineController extends AbstractController
 {
+    public function __construct(private readonly \Symfony\Contracts\Translation\TranslatorInterface $translator)
+    {
+    }
     #[Route('/person/{id}/life-line', name: 'app_person_life_line')]
-    public function index(Person $person, TranslatorInterface $translator): Response
+    public function index(Person $person): Response
     {
         $events = [];
 
@@ -22,8 +25,8 @@ class LifeLineController extends AbstractController
             $events[] = [
                 'date' => $person->getBirth(),
                 'type' => 'birth',
-                'label' => $translator->trans('life_line.birth.label'),
-                'message' => $translator->trans('life_line.birth.message', [
+                'label' => $this->translator->trans('life_line.birth.label'),
+                'message' => $this->translator->trans('life_line.birth.message', [
                     'name' => $person->getFullName(),
                     'gender' => $person->getGender(),
                     'year' => $hasBirthDate ? $person->getBirth()->format('Y') : 'empty',
@@ -40,8 +43,8 @@ class LifeLineController extends AbstractController
             $events[] = [
                 'date' => $union->getStartsAt(),
                 'type' => 'union',
-                'label' => $translator->trans('life_line.union.label'),
-                'message' => $translator->trans('life_line.union.message', [
+                'label' => $this->translator->trans('life_line.union.label'),
+                'message' => $this->translator->trans('life_line.union.message', [
                     'name' => $person->getFullName(),
                     'gender' => $person->getGender(),
                     'partner' => $hasPartner ? $union->getPartner($person)->getFullName() : '?',
@@ -57,8 +60,8 @@ class LifeLineController extends AbstractController
                 $events[] = [
                     'date' => $child->getBirth(),
                     'type' => 'child',
-                    'label' => $translator->trans('life_line.child.label'),
-                    'message' => $translator->trans('life_line.child.message', [
+                    'label' => $this->translator->trans('life_line.child.label'),
+                    'message' => $this->translator->trans('life_line.child.message', [
                         'name' => $person->getFullName(),
                         'child' => $child->getFullName(),
                         'child_path' => $this->generateUrl('app_person_life_line', ['id' => $child->getId()]),
@@ -73,8 +76,8 @@ class LifeLineController extends AbstractController
             $events[] = [
                 'date' => $person->getDeath(),
                 'type' => 'death',
-                'label' => $translator->trans('life_line.death.label'),
-                'message' => $translator->trans('life_line.death.message', [
+                'label' => $this->translator->trans('life_line.death.label'),
+                'message' => $this->translator->trans('life_line.death.message', [
                     'name' => $person->getFullName(),
                     'gender' => $person->getGender(),
                     'year' => $person->getDeath()->format('Y'),

--- a/src/Controller/LifeLineController.php
+++ b/src/Controller/LifeLineController.php
@@ -83,14 +83,10 @@ class LifeLineController extends AbstractController
             ];
         }
 
-        $allEventsHaveDate = array_reduce($events, function ($carry, $event) {
-            return $carry && (bool) $event['date'];
-        }, true);
+        $allEventsHaveDate = array_reduce($events, fn($carry, $event) => $carry && (bool) $event['date'], true);
 
         if ($allEventsHaveDate) {
-            usort($events, function ($a, $b) {
-                return $a['date'] <=> $b['date'];
-            });
+            usort($events, fn($a, $b) => $a['date'] <=> $b['date']);
         }
 
         return $this->render('life_line/index.html.twig', [

--- a/src/Controller/LifeLineController.php
+++ b/src/Controller/LifeLineController.php
@@ -13,6 +13,7 @@ class LifeLineController extends AbstractController
     public function __construct(private readonly \Symfony\Contracts\Translation\TranslatorInterface $translator)
     {
     }
+
     #[Route('/person/{id}/life-line', name: 'app_person_life_line')]
     public function index(Person $person): Response
     {

--- a/src/Controller/LifeLineController.php
+++ b/src/Controller/LifeLineController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use DateTimeInterface;
 use App\Entity\Person;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,7 +17,7 @@ class LifeLineController extends AbstractController
         $events = [];
 
         // Get birth event
-        if ($person->getBirth()) {
+        if ($person->getBirth() instanceof DateTimeInterface) {
             $hasBirthDate = !!$person->getBirth();
 
             $events[] = [
@@ -69,7 +70,7 @@ class LifeLineController extends AbstractController
         }
 
         // Get death event
-        if ($person->getDeath()) {
+        if ($person->getDeath() instanceof DateTimeInterface) {
             $events[] = [
                 'date' => $person->getDeath(),
                 'type' => 'death',

--- a/src/Controller/LifeLineController.php
+++ b/src/Controller/LifeLineController.php
@@ -87,10 +87,10 @@ class LifeLineController extends AbstractController
             ];
         }
 
-        $allEventsHaveDate = array_reduce($events, fn ($carry, $event) => $carry && (bool) $event['date'], true);
+        $allEventsHaveDate = array_reduce($events, fn ($carry, $event): bool => $carry && (bool) $event['date'], true);
 
         if ($allEventsHaveDate) {
-            usort($events, fn ($a, $b) => $a['date'] <=> $b['date']);
+            usort($events, fn ($a, $b): int => $a['date'] <=> $b['date']);
         }
 
         return $this->render('life_line/index.html.twig', [

--- a/src/Controller/LifeLineController.php
+++ b/src/Controller/LifeLineController.php
@@ -17,7 +17,7 @@ class LifeLineController extends AbstractController
         $events = [];
 
         // Get birth event
-        if ($person->getBirth() instanceof DateTimeInterface) {
+        if ($person->getBirth() instanceof \DateTimeInterface) {
             $hasBirthDate = (bool) $person->getBirth();
 
             $events[] = [
@@ -70,7 +70,7 @@ class LifeLineController extends AbstractController
         }
 
         // Get death event
-        if ($person->getDeath() instanceof DateTimeInterface) {
+        if ($person->getDeath() instanceof \DateTimeInterface) {
             $events[] = [
                 'date' => $person->getDeath(),
                 'type' => 'death',

--- a/src/Controller/LifeLineController.php
+++ b/src/Controller/LifeLineController.php
@@ -83,10 +83,10 @@ class LifeLineController extends AbstractController
             ];
         }
 
-        $allEventsHaveDate = array_reduce($events, fn($carry, $event) => $carry && (bool) $event['date'], true);
+        $allEventsHaveDate = array_reduce($events, fn ($carry, $event) => $carry && (bool) $event['date'], true);
 
         if ($allEventsHaveDate) {
-            usort($events, fn($a, $b) => $a['date'] <=> $b['date']);
+            usort($events, fn ($a, $b) => $a['date'] <=> $b['date']);
         }
 
         return $this->render('life_line/index.html.twig', [

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class PersonController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager, private readonly \App\Service\ImageManager $imageManager,
+        private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager, private readonly ImageManager $imageManager,
     ) {
     }
 

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -61,6 +61,7 @@ class PersonController extends AbstractController
                 if ($person->getPortrait()) {
                     $this->imageManager->remove($person->getPortrait());
                 }
+
                 $person->setPortrait($path);
             }
 
@@ -93,6 +94,7 @@ class PersonController extends AbstractController
             if ($person->getPortrait()) {
                 $this->imageManager->remove($person->getPortrait());
             }
+
             $this->entityManager->remove($person);
             $this->entityManager->flush();
             $this->addFlash(

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -20,6 +20,7 @@ class PersonController extends AbstractController
         private readonly TranslatorInterface $translator, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager, private readonly \App\Service\ImageManager $imageManager,
     ) {
     }
+
     #[Route('/person/{id}', name: 'app_person_show', methods: ['GET'])]
     #[IsGranted('view', 'person')]
     public function show(Person $person): Response
@@ -28,6 +29,7 @@ class PersonController extends AbstractController
             'person' => $person,
         ]);
     }
+
     #[Route('/person/{id}/unions', name: 'app_person_unions', methods: ['GET'])]
     #[IsGranted('edit', 'person')]
     public function unions(Person $person): Response
@@ -36,6 +38,7 @@ class PersonController extends AbstractController
             'person' => $person,
         ]);
     }
+
     #[Route('/person/{id}/edit', name: 'app_person_edit', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'person')]
     public function edit(
@@ -77,6 +80,7 @@ class PersonController extends AbstractController
             'tree' => $person->getTree(),
         ]);
     }
+
     #[Route('/person/{id}', name: 'app_person_delete', methods: ['POST'])]
     #[IsGranted('delete', 'person')]
     public function delete(
@@ -104,6 +108,7 @@ class PersonController extends AbstractController
 
         return $this->redirectToRoute('app_tree_show', ['id' => $tree->getId()], Response::HTTP_SEE_OTHER);
     }
+
     #[Route('/person/{id}/tree', name: 'app_person_tree', methods: ['GET'])]
     #[IsGranted('view', 'person')]
     public function tree(Person $person, Request $request): Response

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -14,7 +14,6 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-
 #[Route('/person')]
 class PersonController extends AbstractController
 {

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -14,15 +14,13 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[Route('/person')]
 class PersonController extends AbstractController
 {
     public function __construct(
         private readonly TranslatorInterface $translator,
     ) {
     }
-
-    #[Route('/{id}', name: 'app_person_show', methods: ['GET'])]
+    #[Route('/person/{id}', name: 'app_person_show', methods: ['GET'])]
     #[IsGranted('view', 'person')]
     public function show(Person $person): Response
     {
@@ -30,8 +28,7 @@ class PersonController extends AbstractController
             'person' => $person,
         ]);
     }
-
-    #[Route('/{id}/unions', name: 'app_person_unions', methods: ['GET'])]
+    #[Route('/person/{id}/unions', name: 'app_person_unions', methods: ['GET'])]
     #[IsGranted('edit', 'person')]
     public function unions(Person $person): Response
     {
@@ -39,8 +36,7 @@ class PersonController extends AbstractController
             'person' => $person,
         ]);
     }
-
-    #[Route('/{id}/edit', name: 'app_person_edit', methods: ['GET', 'POST'])]
+    #[Route('/person/{id}/edit', name: 'app_person_edit', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'person')]
     public function edit(
         Request $request,
@@ -83,8 +79,7 @@ class PersonController extends AbstractController
             'tree' => $person->getTree(),
         ]);
     }
-
-    #[Route('/{id}', name: 'app_person_delete', methods: ['POST'])]
+    #[Route('/person/{id}', name: 'app_person_delete', methods: ['POST'])]
     #[IsGranted('delete', 'person')]
     public function delete(
         Request $request,
@@ -113,8 +108,7 @@ class PersonController extends AbstractController
 
         return $this->redirectToRoute('app_tree_show', ['id' => $tree->getId()], Response::HTTP_SEE_OTHER);
     }
-
-    #[Route('/{id}/tree', name: 'app_person_tree', methods: ['GET'])]
+    #[Route('/person/{id}/tree', name: 'app_person_tree', methods: ['GET'])]
     #[IsGranted('view', 'person')]
     public function tree(Person $person, Request $request): Response
     {

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -20,7 +20,8 @@ class PersonController extends AbstractController
 {
     public function __construct(
         private TranslatorInterface $translator,
-    ) {}
+    ) {
+    }
 
     #[Route('/{id}', name: 'app_person_show', methods: ['GET'])]
     #[IsGranted('view', 'person')]

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class PersonController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator,
+        private readonly TranslatorInterface $translator, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager, private readonly \App\Service\ImageManager $imageManager,
     ) {
     }
     #[Route('/person/{id}', name: 'app_person_show', methods: ['GET'])]
@@ -41,8 +41,6 @@ class PersonController extends AbstractController
     public function edit(
         Request $request,
         Person $person,
-        EntityManagerInterface $entityManager,
-        ImageManager $imageManager,
     ): Response {
         $form = $this->createForm(PersonType::class, $person);
         $form->handleRequest($request);
@@ -56,14 +54,14 @@ class PersonController extends AbstractController
             }
 
             if ($form->get('portrait')->getData()) {
-                $path = $imageManager->save($form->get('portrait')->getData(), $request);
+                $path = $this->imageManager->save($form->get('portrait')->getData(), $request);
                 if ($person->getPortrait()) {
-                    $imageManager->remove($person->getPortrait());
+                    $this->imageManager->remove($person->getPortrait());
                 }
                 $person->setPortrait($path);
             }
 
-            $entityManager->flush();
+            $this->entityManager->flush();
 
             $this->addFlash(
                 'success',
@@ -84,17 +82,15 @@ class PersonController extends AbstractController
     public function delete(
         Request $request,
         Person $person,
-        EntityManagerInterface $entityManager,
-        ImageManager $imageManager,
     ): Response {
         $tree = $person->getTree();
 
         if ($this->isCsrfTokenValid('delete'.$person->getId(), $request->request->get('_token'))) {
             if ($person->getPortrait()) {
-                $imageManager->remove($person->getPortrait());
+                $this->imageManager->remove($person->getPortrait());
             }
-            $entityManager->remove($person);
-            $entityManager->flush();
+            $this->entityManager->remove($person);
+            $this->entityManager->flush();
             $this->addFlash(
                 'success',
                 $this->translator->trans('person.delete.success', ['name' => $person->getFullName()]),

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -95,7 +95,7 @@ class PersonController extends AbstractController
     ): Response {
         $tree = $person->getTree();
 
-        if ($this->isCsrfTokenValid('delete' . $person->getId(), $request->request->get('_token'))) {
+        if ($this->isCsrfTokenValid('delete'.$person->getId(), $request->request->get('_token'))) {
             if ($person->getPortrait()) {
                 $imageManager->remove($person->getPortrait());
             }

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class PersonController extends AbstractController
 {
     public function __construct(
-        private TranslatorInterface $translator,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -69,7 +69,7 @@ class PersonController extends AbstractController
             }
 
             $entityManager->flush();
-            
+
             $this->addFlash(
                 'success',
                 $this->translator->trans('person.edit.success', ['name' => $person->getFullName()]),

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -55,7 +55,7 @@ class RegistrationController extends AbstractController
             // do anything else you need here, like send an email
 
             $this->addFlash(
-                'success', 
+                'success',
                 $this->translator->trans('profile.registration.success')
             );
 
@@ -77,7 +77,7 @@ class RegistrationController extends AbstractController
             $this->emailVerifier->handleEmailConfirmation($request, $this->getUser());
         } catch (VerifyEmailExceptionInterface $exception) {
             $this->addFlash(
-                'verify_email_error', 
+                'verify_email_error',
                 $this->translator->trans($exception->getReason(), [], 'VerifyEmailBundle')
             );
 
@@ -86,7 +86,7 @@ class RegistrationController extends AbstractController
 
         // @TODO Change the redirect on success and handle or remove the flash message in your templates
         $this->addFlash(
-            'success', 
+            'success',
             $this->translator->trans('profile.email.verified')
         );
 

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -21,11 +21,13 @@ class RegistrationController extends AbstractController
     public function __construct(
         private readonly EmailVerifier $emailVerifier,
         private readonly TranslatorInterface $translator,
+        private readonly \Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface $userPasswordHasher,
+        private readonly \Doctrine\ORM\EntityManagerInterface $entityManager,
     ) {
     }
 
     #[Route('/register', name: 'app_register')]
-    public function register(Request $request, UserPasswordHasherInterface $userPasswordHasher, EntityManagerInterface $entityManager): Response
+    public function register(Request $request): Response
     {
         $user = new User();
         $form = $this->createForm(RegistrationFormType::class, $user);
@@ -34,14 +36,14 @@ class RegistrationController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             // encode the plain password
             $user->setPassword(
-                $userPasswordHasher->hashPassword(
+                $this->userPasswordHasher->hashPassword(
                     $user,
                     $form->get('plainPassword')->getData()
                 )
             );
 
-            $entityManager->persist($user);
-            $entityManager->flush();
+            $this->entityManager->persist($user);
+            $this->entityManager->flush();
 
             // generate a signed url and email it to the user
             $this->emailVerifier->sendEmailConfirmation(

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -19,8 +19,8 @@ use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
 class RegistrationController extends AbstractController
 {
     public function __construct(
-        private EmailVerifier $emailVerifier,
-        private TranslatorInterface $translator,
+        private readonly EmailVerifier $emailVerifier,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -21,7 +21,8 @@ class RegistrationController extends AbstractController
     public function __construct(
         private EmailVerifier $emailVerifier,
         private TranslatorInterface $translator,
-    ) {}
+    ) {
+    }
 
     #[Route('/register', name: 'app_register')]
     public function register(Request $request, UserPasswordHasherInterface $userPasswordHasher, EntityManagerInterface $entityManager): Response

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -78,10 +78,10 @@ class RegistrationController extends AbstractController
         // validate email confirmation link, sets User::isVerified=true and persists
         try {
             $this->emailVerifier->handleEmailConfirmation($request, $this->getUser());
-        } catch (VerifyEmailExceptionInterface $exception) {
+        } catch (VerifyEmailExceptionInterface $verifyEmailException) {
             $this->addFlash(
                 'verify_email_error',
-                $this->translator->trans($exception->getReason(), [], 'VerifyEmailBundle')
+                $this->translator->trans($verifyEmailException->getReason(), [], 'VerifyEmailBundle')
             );
 
             return $this->redirectToRoute('app_register');

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -21,8 +21,8 @@ class RegistrationController extends AbstractController
     public function __construct(
         private readonly EmailVerifier $emailVerifier,
         private readonly TranslatorInterface $translator,
-        private readonly \Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface $userPasswordHasher,
-        private readonly \Doctrine\ORM\EntityManagerInterface $entityManager,
+        private readonly UserPasswordHasherInterface $userPasswordHasher,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -12,17 +12,17 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class SecurityController extends AbstractController
 {
+    public function __construct(private readonly \Symfony\Component\Security\Http\Authentication\AuthenticationUtils $authenticationUtils)
+    {
+    }
     #[Route(path: '/login', name: 'app_login')]
-    public function login(AuthenticationUtils $authenticationUtils): Response
+    public function login(): Response
     {
         $form = $this->createForm(LoginFormType::class);
-
         // get the login error if there is one
-        $error = $authenticationUtils->getLastAuthenticationError();
-
+        $error = $this->authenticationUtils->getLastAuthenticationError();
         // last username entered by the user
-        $lastUsername = $authenticationUtils->getLastUsername();
-
+        $lastUsername = $this->authenticationUtils->getLastUsername();
         return $this->render('security/login.html.twig', [
             'form' => $form->createView(),
             'last_username' => $lastUsername,

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -34,6 +34,6 @@ class SecurityController extends AbstractController
     #[Route(path: '/logout', name: 'app_logout')]
     public function logout(): void
     {
-        throw new LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');
+        throw new \LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');
     }
 }

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
+use LogicException;
 use App\Form\LoginFormType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
@@ -31,6 +34,6 @@ class SecurityController extends AbstractController
     #[Route(path: '/logout', name: 'app_logout')]
     public function logout(): void
     {
-        throw new \LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');
+        throw new LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');
     }
 }

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -15,6 +15,7 @@ class SecurityController extends AbstractController
     public function __construct(private readonly \Symfony\Component\Security\Http\Authentication\AuthenticationUtils $authenticationUtils)
     {
     }
+
     #[Route(path: '/login', name: 'app_login')]
     public function login(): Response
     {

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use LogicException;
 use App\Form\LoginFormType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -12,7 +12,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class SecurityController extends AbstractController
 {
-    public function __construct(private readonly \Symfony\Component\Security\Http\Authentication\AuthenticationUtils $authenticationUtils)
+    public function __construct(private readonly AuthenticationUtils $authenticationUtils)
     {
     }
 

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -24,6 +24,7 @@ class SecurityController extends AbstractController
         $error = $this->authenticationUtils->getLastAuthenticationError();
         // last username entered by the user
         $lastUsername = $this->authenticationUtils->getLastUsername();
+
         return $this->render('security/login.html.twig', [
             'form' => $form->createView(),
             'last_username' => $lastUsername,

--- a/src/Controller/SourceController.php
+++ b/src/Controller/SourceController.php
@@ -19,7 +19,8 @@ class SourceController extends AbstractController
 {
     public function __construct(
         private TranslatorInterface $translator,
-    ) {}
+    ) {
+    }
     
     #[Route('/', name: 'app_source_index', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'person')]

--- a/src/Controller/SourceController.php
+++ b/src/Controller/SourceController.php
@@ -17,12 +17,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class SourceController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator,
+        private readonly TranslatorInterface $translator, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager,
     ) {
     }
     #[Route('/person/{personId}/source/', name: 'app_source_index', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'person')]
-    public function index(Request $request, EntityManagerInterface $entityManager, #[MapEntity(id: 'personId')] Person $person): Response
+    public function index(Request $request, #[MapEntity(id: 'personId')] Person $person): Response
     {
         $source = new Source();
         $createForm = $this->createForm(SourceType::class, $source);
@@ -30,8 +30,8 @@ class SourceController extends AbstractController
 
         if ($createForm->isSubmitted() && $createForm->isValid()) {
             $source->setPerson($person);
-            $entityManager->persist($source);
-            $entityManager->flush();
+            $this->entityManager->persist($source);
+            $this->entityManager->flush();
 
             $this->addFlash(
                 'success',
@@ -54,7 +54,6 @@ class SourceController extends AbstractController
     public function edit(
         Request $request,
         Source $source,
-        EntityManagerInterface $entityManager,
         #[MapEntity(id: 'personId')]
         Person $person,
     ): Response {
@@ -65,7 +64,7 @@ class SourceController extends AbstractController
         $editForm->handleRequest($request);
 
         if ($editForm->isSubmitted() && $editForm->isValid()) {
-            $entityManager->flush();
+            $this->entityManager->flush();
 
             $this->addFlash(
                 'success',
@@ -85,13 +84,13 @@ class SourceController extends AbstractController
     }
     #[Route('/person/{personId}/source/{id}', name: 'app_source_delete', methods: ['POST'])]
     #[IsGranted('edit', 'person')]
-    public function delete(Request $request, Source $source, EntityManagerInterface $entityManager, #[MapEntity(id: 'personId')] Person $person): Response
+    public function delete(Request $request, Source $source, #[MapEntity(id: 'personId')] Person $person): Response
     {
         $this->assertSourceBelongsToPerson($source, $person);
 
         if ($this->isCsrfTokenValid('delete'.$source->getId(), $request->request->get('_token'))) {
-            $entityManager->remove($source);
-            $entityManager->flush();
+            $this->entityManager->remove($source);
+            $this->entityManager->flush();
 
             $this->addFlash(
                 'success',

--- a/src/Controller/SourceController.php
+++ b/src/Controller/SourceController.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class SourceController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager,
+        private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/src/Controller/SourceController.php
+++ b/src/Controller/SourceController.php
@@ -20,6 +20,7 @@ class SourceController extends AbstractController
         private readonly TranslatorInterface $translator, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager,
     ) {
     }
+
     #[Route('/person/{personId}/source/', name: 'app_source_index', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'person')]
     public function index(Request $request, #[MapEntity(id: 'personId')] Person $person): Response
@@ -49,6 +50,7 @@ class SourceController extends AbstractController
             'editing_source' => null,
         ]);
     }
+
     #[Route('/person/{personId}/source/{id}/edit', name: 'app_source_edit', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'person')]
     public function edit(
@@ -82,6 +84,7 @@ class SourceController extends AbstractController
             'editing_source' => $source,
         ]);
     }
+
     #[Route('/person/{personId}/source/{id}', name: 'app_source_delete', methods: ['POST'])]
     #[IsGranted('edit', 'person')]
     public function delete(Request $request, Source $source, #[MapEntity(id: 'personId')] Person $person): Response
@@ -105,6 +108,7 @@ class SourceController extends AbstractController
 
         return $this->redirectToRoute('app_source_index', ['personId' => $person->getId()], Response::HTTP_SEE_OTHER);
     }
+
     private function assertSourceBelongsToPerson(Source $source, Person $person): void
     {
         if ($source->getPerson()?->getId() !== $person->getId()) {

--- a/src/Controller/SourceController.php
+++ b/src/Controller/SourceController.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class SourceController extends AbstractController
 {
     public function __construct(
-        private TranslatorInterface $translator,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 

--- a/src/Controller/SourceController.php
+++ b/src/Controller/SourceController.php
@@ -56,7 +56,8 @@ class SourceController extends AbstractController
         Request $request,
         Source $source,
         EntityManagerInterface $entityManager,
-        #[MapEntity(id: 'personId')] Person $person,
+        #[MapEntity(id: 'personId')]
+        Person $person,
     ): Response {
         $this->assertSourceBelongsToPerson($source, $person);
 

--- a/src/Controller/SourceController.php
+++ b/src/Controller/SourceController.php
@@ -39,6 +39,7 @@ class SourceController extends AbstractController
                 'success',
                 $this->translator->trans('source.new.success')
             );
+
             return $this->redirectToRoute('app_source_index', ['personId' => $person->getId()], Response::HTTP_SEE_OTHER);
         }
 

--- a/src/Controller/SourceController.php
+++ b/src/Controller/SourceController.php
@@ -14,15 +14,13 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[Route('/person/{personId}/source')]
 class SourceController extends AbstractController
 {
     public function __construct(
         private readonly TranslatorInterface $translator,
     ) {
     }
-
-    #[Route('/', name: 'app_source_index', methods: ['GET', 'POST'])]
+    #[Route('/person/{personId}/source/', name: 'app_source_index', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'person')]
     public function index(Request $request, EntityManagerInterface $entityManager, #[MapEntity(id: 'personId')] Person $person): Response
     {
@@ -51,8 +49,7 @@ class SourceController extends AbstractController
             'editing_source' => null,
         ]);
     }
-
-    #[Route('/{id}/edit', name: 'app_source_edit', methods: ['GET', 'POST'])]
+    #[Route('/person/{personId}/source/{id}/edit', name: 'app_source_edit', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'person')]
     public function edit(
         Request $request,
@@ -86,8 +83,7 @@ class SourceController extends AbstractController
             'editing_source' => $source,
         ]);
     }
-
-    #[Route('/{id}', name: 'app_source_delete', methods: ['POST'])]
+    #[Route('/person/{personId}/source/{id}', name: 'app_source_delete', methods: ['POST'])]
     #[IsGranted('edit', 'person')]
     public function delete(Request $request, Source $source, EntityManagerInterface $entityManager, #[MapEntity(id: 'personId')] Person $person): Response
     {
@@ -110,7 +106,6 @@ class SourceController extends AbstractController
 
         return $this->redirectToRoute('app_source_index', ['personId' => $person->getId()], Response::HTTP_SEE_OTHER);
     }
-
     private function assertSourceBelongsToPerson(Source $source, Person $person): void
     {
         if ($source->getPerson()?->getId() !== $person->getId()) {

--- a/src/Controller/SourceController.php
+++ b/src/Controller/SourceController.php
@@ -21,7 +21,7 @@ class SourceController extends AbstractController
         private TranslatorInterface $translator,
     ) {
     }
-    
+
     #[Route('/', name: 'app_source_index', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'person')]
     public function index(Request $request, EntityManagerInterface $entityManager, #[MapEntity(id: 'personId')] Person $person): Response
@@ -95,7 +95,7 @@ class SourceController extends AbstractController
         if ($this->isCsrfTokenValid('delete'.$source->getId(), $request->request->get('_token'))) {
             $entityManager->remove($source);
             $entityManager->flush();
-            
+
             $this->addFlash(
                 'success',
                 $this->translator->trans('source.delete.success')

--- a/src/Controller/ThemeController.php
+++ b/src/Controller/ThemeController.php
@@ -2,7 +2,6 @@
 
 namespace App\Controller;
 
-use DateTime;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Cookie;

--- a/src/Controller/ThemeController.php
+++ b/src/Controller/ThemeController.php
@@ -19,7 +19,7 @@ class ThemeController extends AbstractController
         $response = new Response();
         $data = json_decode($request->getContent(), true);
         $mode = $data['mode'] ?? 'auto';
-        $expires = new DateTime('+30 days');
+        $expires = new \DateTime('+30 days');
 
         $response->headers->setCookie(
             new Cookie('theme', $mode, $expires)

--- a/src/Controller/ThemeController.php
+++ b/src/Controller/ThemeController.php
@@ -11,7 +11,7 @@ use Symfony\Component\Routing\Attribute\Route;
 
 class ThemeController extends AbstractController
 {
-    public function __construct(private readonly \Psr\Log\LoggerInterface $logger)
+    public function __construct()
     {
     }
     #[Route('/settings/theme', name: 'app_theme', methods: ['post'])]

--- a/src/Controller/ThemeController.php
+++ b/src/Controller/ThemeController.php
@@ -20,7 +20,7 @@ class ThemeController extends AbstractController
         $data = json_decode($request->getContent(), true);
         $mode = $data['mode'] ?? 'auto';
         $expires = new DateTime('+30 days');
-        
+
         $response->headers->setCookie(
             new Cookie('theme', $mode, $expires)
         );

--- a/src/Controller/ThemeController.php
+++ b/src/Controller/ThemeController.php
@@ -2,7 +2,6 @@
 
 namespace App\Controller;
 
-use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Controller/ThemeController.php
+++ b/src/Controller/ThemeController.php
@@ -11,9 +11,6 @@ use Symfony\Component\Routing\Attribute\Route;
 
 class ThemeController extends AbstractController
 {
-    public function __construct()
-    {
-    }
     #[Route('/settings/theme', name: 'app_theme', methods: ['post'])]
     public function setMode(Request $request): Response
     {

--- a/src/Controller/ThemeController.php
+++ b/src/Controller/ThemeController.php
@@ -9,10 +9,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route('/settings')]
 class ThemeController extends AbstractController
 {
-    #[Route('/theme', name: 'app_theme', methods: ['post'])]
+    #[Route('/settings/theme', name: 'app_theme', methods: ['post'])]
     public function setMode(Request $request, LoggerInterface $logger): Response
     {
         $response = new Response();

--- a/src/Controller/ThemeController.php
+++ b/src/Controller/ThemeController.php
@@ -11,8 +11,11 @@ use Symfony\Component\Routing\Attribute\Route;
 
 class ThemeController extends AbstractController
 {
+    public function __construct(private readonly \Psr\Log\LoggerInterface $logger)
+    {
+    }
     #[Route('/settings/theme', name: 'app_theme', methods: ['post'])]
-    public function setMode(Request $request, LoggerInterface $logger): Response
+    public function setMode(Request $request): Response
     {
         $response = new Response();
         $data = json_decode($request->getContent(), true);

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -24,6 +24,7 @@ class TreeController extends AbstractController
         private readonly TranslatorInterface $translator, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager, private readonly \App\Service\ImageManager $imageManager,
     ) {
     }
+
     #[Route('/project/', name: 'app_tree_index', methods: ['GET'])]
     public function index(#[CurrentUser()] User $currentUser): Response
     {
@@ -31,6 +32,7 @@ class TreeController extends AbstractController
             'trees' => $currentUser->getTrees(),
         ]);
     }
+
     #[Route('/project/new', name: 'app_tree_new', methods: ['GET', 'POST'])]
     public function new(#[CurrentUser()] User $user): Response
     {
@@ -52,6 +54,7 @@ class TreeController extends AbstractController
 
         return $this->redirectToRoute('app_tree_index', [], Response::HTTP_SEE_OTHER);
     }
+
     #[Route('/project/{id}', name: 'app_tree_show', methods: ['GET'])]
     public function show(Tree $tree, Request $request): Response
     {
@@ -90,6 +93,7 @@ class TreeController extends AbstractController
             'members_count' => $members->count(),
         ]);
     }
+
     #[Route('/project/{id}/edit', name: 'app_tree_edit', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'tree')]
     public function edit(Request $request, Tree $tree): Response
@@ -113,6 +117,7 @@ class TreeController extends AbstractController
             'form' => $form,
         ]);
     }
+
     #[Route('/project/{id}', name: 'app_tree_delete', methods: ['POST'])]
     #[IsGranted('delete', 'tree')]
     public function delete(Request $request, Tree $tree): Response
@@ -134,6 +139,7 @@ class TreeController extends AbstractController
 
         return $this->redirectToRoute('app_tree_index', [], Response::HTTP_SEE_OTHER);
     }
+
     #[Route('/project/{id}/members', name: 'app_tree_members_add', methods: ['GET', 'POST'])]
     #[IsGranted('add_member', 'tree')]
     public function addMember(

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -21,7 +21,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class TreeController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator,
+        private readonly TranslatorInterface $translator, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager, private readonly \App\Service\ImageManager $imageManager,
     ) {
     }
     #[Route('/project/', name: 'app_tree_index', methods: ['GET'])]
@@ -32,7 +32,7 @@ class TreeController extends AbstractController
         ]);
     }
     #[Route('/project/new', name: 'app_tree_new', methods: ['GET', 'POST'])]
-    public function new(EntityManagerInterface $entityManager, #[CurrentUser()] User $user): Response
+    public function new(#[CurrentUser()] User $user): Response
     {
         $total = $user->getTrees()->count();
         $tree = new Tree();
@@ -42,8 +42,8 @@ class TreeController extends AbstractController
             ->setName('Family tree #'.($total + 1))
         ;
 
-        $entityManager->persist($tree);
-        $entityManager->flush();
+        $this->entityManager->persist($tree);
+        $this->entityManager->flush();
 
         $this->addFlash(
             'success',
@@ -92,13 +92,13 @@ class TreeController extends AbstractController
     }
     #[Route('/project/{id}/edit', name: 'app_tree_edit', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'tree')]
-    public function edit(Request $request, Tree $tree, EntityManagerInterface $entityManager): Response
+    public function edit(Request $request, Tree $tree): Response
     {
         $form = $this->createForm(TreeType::class, $tree);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $entityManager->flush();
+            $this->entityManager->flush();
 
             $this->addFlash(
                 'success',
@@ -115,11 +115,11 @@ class TreeController extends AbstractController
     }
     #[Route('/project/{id}', name: 'app_tree_delete', methods: ['POST'])]
     #[IsGranted('delete', 'tree')]
-    public function delete(Request $request, Tree $tree, EntityManagerInterface $entityManager): Response
+    public function delete(Request $request, Tree $tree): Response
     {
         if ($this->isCsrfTokenValid('delete'.$tree->getId(), $request->request->get('_token'))) {
-            $entityManager->remove($tree);
-            $entityManager->flush();
+            $this->entityManager->remove($tree);
+            $this->entityManager->flush();
 
             $this->addFlash(
                 'success',
@@ -138,8 +138,6 @@ class TreeController extends AbstractController
     #[IsGranted('add_member', 'tree')]
     public function addMember(
         Request $request,
-        EntityManagerInterface $entityManager,
-        ImageManager $imageManager,
         Tree $tree,
     ): Response {
         $person = new Person();
@@ -155,13 +153,13 @@ class TreeController extends AbstractController
             }
 
             if ($form->get('portrait')->getData()) {
-                $path = $imageManager->save($form->get('portrait')->getData(), $request);
+                $path = $this->imageManager->save($form->get('portrait')->getData(), $request);
                 $person->setPortrait($path);
             }
 
             $tree->addMember($person);
-            $entityManager->persist($person);
-            $entityManager->flush();
+            $this->entityManager->persist($person);
+            $this->entityManager->flush();
 
             $this->addFlash(
                 'success',

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -42,7 +42,7 @@ class TreeController extends AbstractController
         $tree = new Tree();
         $tree
             ->setOwner($user)
-            ->setCreatedAt(new DateTimeImmutable())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setName('Family tree #'.($total + 1))
         ;
 

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -77,7 +77,7 @@ class TreeController extends AbstractController
 
         // Tri par ordre alphabétique
         $orderedMembers = $members->toArray();
-        usort($orderedMembers, fn($a, $b) => strcmp(trim($a->getFullName()), trim($b->getFullName())));
+        usort($orderedMembers, fn ($a, $b) => strcmp(trim($a->getFullName()), trim($b->getFullName())));
 
         // Groupement par première lettre
         $groupedMembers = array_reduce($orderedMembers, function (array $groupedMembers, Person $member) {

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -18,23 +18,20 @@ use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[Route('/project')]
 class TreeController extends AbstractController
 {
     public function __construct(
         private readonly TranslatorInterface $translator,
     ) {
     }
-
-    #[Route('/', name: 'app_tree_index', methods: ['GET'])]
+    #[Route('/project/', name: 'app_tree_index', methods: ['GET'])]
     public function index(#[CurrentUser()] User $currentUser): Response
     {
         return $this->render('tree/index.html.twig', [
             'trees' => $currentUser->getTrees(),
         ]);
     }
-
-    #[Route('/new', name: 'app_tree_new', methods: ['GET', 'POST'])]
+    #[Route('/project/new', name: 'app_tree_new', methods: ['GET', 'POST'])]
     public function new(EntityManagerInterface $entityManager, #[CurrentUser()] User $user): Response
     {
         $total = $user->getTrees()->count();
@@ -55,8 +52,7 @@ class TreeController extends AbstractController
 
         return $this->redirectToRoute('app_tree_index', [], Response::HTTP_SEE_OTHER);
     }
-
-    #[Route('/{id}', name: 'app_tree_show', methods: ['GET'])]
+    #[Route('/project/{id}', name: 'app_tree_show', methods: ['GET'])]
     public function show(Tree $tree, Request $request): Response
     {
         $form = $this->createForm(MembersSearchType::class);
@@ -94,8 +90,7 @@ class TreeController extends AbstractController
             'members_count' => $members->count(),
         ]);
     }
-
-    #[Route('/{id}/edit', name: 'app_tree_edit', methods: ['GET', 'POST'])]
+    #[Route('/project/{id}/edit', name: 'app_tree_edit', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'tree')]
     public function edit(Request $request, Tree $tree, EntityManagerInterface $entityManager): Response
     {
@@ -118,8 +113,7 @@ class TreeController extends AbstractController
             'form' => $form,
         ]);
     }
-
-    #[Route('/{id}', name: 'app_tree_delete', methods: ['POST'])]
+    #[Route('/project/{id}', name: 'app_tree_delete', methods: ['POST'])]
     #[IsGranted('delete', 'tree')]
     public function delete(Request $request, Tree $tree, EntityManagerInterface $entityManager): Response
     {
@@ -140,8 +134,7 @@ class TreeController extends AbstractController
 
         return $this->redirectToRoute('app_tree_index', [], Response::HTTP_SEE_OTHER);
     }
-
-    #[Route('/{id}/members', name: 'app_tree_members_add', methods: ['GET', 'POST'])]
+    #[Route('/project/{id}/members', name: 'app_tree_members_add', methods: ['GET', 'POST'])]
     #[IsGranted('add_member', 'tree')]
     public function addMember(
         Request $request,

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -71,6 +71,7 @@ class TreeController extends AbstractController
                 if ('' !== $name && '0' !== $name) {
                     return str_contains(mb_strtoupper($member->getFullName()), $name);
                 }
+
                 return true;
             });
         }
@@ -111,6 +112,7 @@ class TreeController extends AbstractController
                 'success',
                 $this->translator->trans('tree.edit.success', ['name' => $tree->getName()])
             );
+
             return $this->redirectToRoute('app_tree_index', [], Response::HTTP_SEE_OTHER);
         }
 

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -68,7 +68,7 @@ class TreeController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             $name = mb_strtoupper($form->get('name')->getData());
             $members = $members->filter(function (Person $member) use ($name) {
-                if ($name !== '' && $name !== '0') {
+                if ('' !== $name && '0' !== $name) {
                     return str_contains(mb_strtoupper($member->getFullName()), $name);
                 }
                 return true;

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use DateTimeImmutable;
 use App\Entity\Person;
 use App\Entity\Tree;
 use App\Entity\User;
@@ -40,7 +41,7 @@ class TreeController extends AbstractController
         $tree = new Tree();
         $tree
             ->setOwner($user)
-            ->setCreatedAt(new \DateTimeImmutable())
+            ->setCreatedAt(new DateTimeImmutable())
             ->setName('Family tree' . ' #' . ($total + 1))
         ;
 

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class TreeController extends AbstractController
 {
     public function __construct(
-        private TranslatorInterface $translator,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -77,9 +77,7 @@ class TreeController extends AbstractController
 
         // Tri par ordre alphabétique
         $orderedMembers = $members->toArray();
-        usort($orderedMembers, function ($a, $b) {
-            return strcmp(trim($a->getFullName()), trim($b->getFullName()));
-        });
+        usort($orderedMembers, fn($a, $b) => strcmp(trim($a->getFullName()), trim($b->getFullName())));
 
         // Groupement par première lettre
         $groupedMembers = array_reduce($orderedMembers, function (array $groupedMembers, Person $member) {

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -77,7 +77,7 @@ class TreeController extends AbstractController
 
         // Tri par ordre alphabétique
         $orderedMembers = $members->toArray();
-        usort($orderedMembers, fn ($a, $b) => strcmp(trim($a->getFullName()), trim($b->getFullName())));
+        usort($orderedMembers, fn ($a, $b): int => strcmp(trim($a->getFullName()), trim($b->getFullName())));
 
         // Groupement par première lettre
         $groupedMembers = array_reduce($orderedMembers, function (array $groupedMembers, Person $member) {

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -24,7 +24,8 @@ class TreeController extends AbstractController
 {
     public function __construct(
         private TranslatorInterface $translator,
-    ) {}
+    ) {
+    }
 
     #[Route('/', name: 'app_tree_index', methods: ['GET'])]
     public function index(#[CurrentUser()] User $currentUser): Response

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -60,6 +60,7 @@ class TreeController extends AbstractController
     {
         $form = $this->createForm(MembersSearchType::class);
         $form->handleRequest($request);
+
         $members = $tree->getMembers();
 
         // Filtre de recherche

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -21,7 +21,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class TreeController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager, private readonly \App\Service\ImageManager $imageManager,
+        private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager, private readonly ImageManager $imageManager,
     ) {
     }
 

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -2,7 +2,6 @@
 
 namespace App\Controller;
 
-use DateTimeImmutable;
 use App\Entity\Person;
 use App\Entity\Tree;
 use App\Entity\User;

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -66,9 +66,9 @@ class TreeController extends AbstractController
         // Filtre de recherche
         if ($form->isSubmitted() && $form->isValid()) {
             $name = mb_strtoupper((string) $form->get('name')->getData());
-            $members = $members->filter(function (Person $member) use ($name): bool {
+            $members = $members->filter(function (Person $person) use ($name): bool {
                 if ('' !== $name && '0' !== $name) {
-                    return str_contains(mb_strtoupper($member->getFullName()), $name);
+                    return str_contains(mb_strtoupper($person->getFullName()), $name);
                 }
 
                 return true;
@@ -80,9 +80,9 @@ class TreeController extends AbstractController
         usort($orderedMembers, fn ($a, $b): int => strcmp(trim($a->getFullName()), trim($b->getFullName())));
 
         // Groupement par première lettre
-        $groupedMembers = array_reduce($orderedMembers, function (array $groupedMembers, Person $member): array {
-            $firstLetter = strtoupper(mb_substr(trim($member->getFullName()), 0, 1));
-            $groupedMembers[$firstLetter][] = $member;
+        $groupedMembers = array_reduce($orderedMembers, function (array $groupedMembers, Person $person): array {
+            $firstLetter = strtoupper(mb_substr(trim($person->getFullName()), 0, 1));
+            $groupedMembers[$firstLetter][] = $person;
 
             return $groupedMembers;
         }, []);

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -42,7 +42,7 @@ class TreeController extends AbstractController
         $tree
             ->setOwner($user)
             ->setCreatedAt(new DateTimeImmutable())
-            ->setName('Family tree' . ' #' . ($total + 1))
+            ->setName('Family tree #' . ($total + 1))
         ;
 
         $entityManager->persist($tree);

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -43,7 +43,7 @@ class TreeController extends AbstractController
         $tree
             ->setOwner($user)
             ->setCreatedAt(new DateTimeImmutable())
-            ->setName('Family tree #' . ($total + 1))
+            ->setName('Family tree #'.($total + 1))
         ;
 
         $entityManager->persist($tree);

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -39,7 +39,7 @@ class TreeController extends AbstractController
         $total = $user->getTrees()->count();
         $tree = new Tree();
         $tree
-            ->setOwner($user)
+            ->setUser($user)
             ->setCreatedAt(new \DateTimeImmutable())
             ->setName('Family tree #'.($total + 1))
         ;

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -67,7 +67,7 @@ class TreeController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             $name = mb_strtoupper($form->get('name')->getData());
             $members = $members->filter(function (Person $member) use ($name) {
-                if ($name) {
+                if ($name !== '' && $name !== '0') {
                     return str_contains(mb_strtoupper($member->getFullName()), $name);
                 }
                 return true;

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -149,7 +149,7 @@ class TreeController extends AbstractController
         Request $request,
         EntityManagerInterface $entityManager,
         ImageManager $imageManager,
-        Tree $tree
+        Tree $tree,
     ): Response {
         $person = new Person();
         $form = $this->createForm(PersonType::class, $person);

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -65,7 +65,7 @@ class TreeController extends AbstractController
 
         // Filtre de recherche
         if ($form->isSubmitted() && $form->isValid()) {
-            $name = mb_strtoupper($form->get('name')->getData());
+            $name = mb_strtoupper((string) $form->get('name')->getData());
             $members = $members->filter(function (Person $member) use ($name) {
                 if ('' !== $name && '0' !== $name) {
                     return str_contains(mb_strtoupper($member->getFullName()), $name);

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -49,7 +49,7 @@ class TreeController extends AbstractController
         $entityManager->flush();
 
         $this->addFlash(
-            'success', 
+            'success',
             $this->translator->trans('tree.new.success', ['name' => $tree->getName()])
         );
 
@@ -108,7 +108,7 @@ class TreeController extends AbstractController
             $entityManager->flush();
 
             $this->addFlash(
-                'success', 
+                'success',
                 $this->translator->trans('tree.edit.success', ['name' => $tree->getName()])
             );
             return $this->redirectToRoute('app_tree_index', [], Response::HTTP_SEE_OTHER);
@@ -129,12 +129,12 @@ class TreeController extends AbstractController
             $entityManager->flush();
 
             $this->addFlash(
-                'success', 
+                'success',
                 $this->translator->trans('tree.delete.success', ['name' => $tree->getName()])
             );
         } else {
             $this->addFlash(
-                'danger', 
+                'danger',
                 $this->translator->trans('tree.delete.error', ['name' => $tree->getName()])
             );
         }
@@ -172,7 +172,7 @@ class TreeController extends AbstractController
             $entityManager->flush();
 
             $this->addFlash(
-                'success', 
+                'success',
                 $this->translator->trans('tree.add_member.success', ['name' => $person->getFullName()])
             );
 

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -89,7 +89,6 @@ class TreeController extends AbstractController
             return $groupedMembers;
         }, []);
 
-
         return $this->render('tree/show.html.twig', [
             'tree' => $tree,
             'form' => $form->createView(),

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -66,7 +66,7 @@ class TreeController extends AbstractController
         // Filtre de recherche
         if ($form->isSubmitted() && $form->isValid()) {
             $name = mb_strtoupper((string) $form->get('name')->getData());
-            $members = $members->filter(function (Person $member) use ($name) {
+            $members = $members->filter(function (Person $member) use ($name): bool {
                 if ('' !== $name && '0' !== $name) {
                     return str_contains(mb_strtoupper($member->getFullName()), $name);
                 }
@@ -80,7 +80,7 @@ class TreeController extends AbstractController
         usort($orderedMembers, fn ($a, $b): int => strcmp(trim($a->getFullName()), trim($b->getFullName())));
 
         // Groupement par première lettre
-        $groupedMembers = array_reduce($orderedMembers, function (array $groupedMembers, Person $member) {
+        $groupedMembers = array_reduce($orderedMembers, function (array $groupedMembers, Person $member): array {
             $firstLetter = strtoupper(mb_substr(trim($member->getFullName()), 0, 1));
             $groupedMembers[$firstLetter][] = $member;
 

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class UnionController extends AbstractController
 {
     public function __construct(
-        private TranslatorInterface $translator,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -7,7 +7,6 @@ use App\Entity\Union;
 use App\Form\PersonSelectType;
 use App\Form\UnionType;
 use App\Repository\PersonRepository;
-use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -105,6 +105,7 @@ class UnionController extends AbstractController
         $unionPartners = $union->getPeople();
         $birthDates = array_map(fn (Person $person) => $person->getBirth(), $unionPartners->toArray());
         $birthDates = array_filter($birthDates, fn ($date) => null !== $date);
+
         $mostRecentBirthDate = count($birthDates) < 1 ? null : max($birthDates);
 
         return $this->render('union/edit.html.twig', [

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -95,7 +95,7 @@ class UnionController extends AbstractController
             ...$union->getChildren()->toArray(),
         ];
 
-        if ($person->getParentUnion()) {
+        if ($person->getParentUnion() instanceof Union) {
             $membersToExclude = [
                 ...$membersToExclude,
                 ...$person->getParentUnion()->getPeople()->toArray(),

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -160,7 +160,7 @@ class UnionController extends AbstractController
             'available_members' => $person->getTree()->getMembers()->toArray(),
             'union_members' => [
                 ...$union->getPeople()->toArray(),
-                ...$union->getChildren()->toArray()
+                ...$union->getChildren()->toArray(),
             ],
         ]);
         $form->handleRequest($request);
@@ -243,7 +243,7 @@ class UnionController extends AbstractController
             'available_members' => $personRepository->getOrphanMembers($person->getTree()),
             'union_members' => [
                 ...$union->getPeople()->toArray(),
-                ...$union->getChildren()->toArray()
+                ...$union->getChildren()->toArray(),
             ],
         ]);
         $form->handleRequest($request);

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class UnionController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager, private readonly \App\Repository\PersonRepository $personRepository,
+        private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager, private readonly PersonRepository $personRepository,
     ) {
     }
 

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -104,7 +104,7 @@ class UnionController extends AbstractController
 
         $unionPartners = $union->getPeople();
         $birthDates = array_map(fn (Person $person): ?\DateTimeInterface => $person->getBirth(), $unionPartners->toArray());
-        $birthDates = array_filter($birthDates, fn ($date): bool => null !== $date);
+        $birthDates = array_filter($birthDates, fn (?\DateTimeInterface $date): bool => null !== $date);
 
         $mostRecentBirthDate = count($birthDates) < 1 ? null : max($birthDates);
 

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -36,7 +36,7 @@ class UnionController extends AbstractController
             $entityManager->flush();
 
             $this->addFlash(
-                'success', 
+                'success',
                 $this->translator->trans('union.new.success')
             );
 
@@ -65,10 +65,11 @@ class UnionController extends AbstractController
     #[Route('/person/{personId}/union/{id}/edit', name: 'app_union_edit', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'union')]
     public function edit(
-        Request $request, 
-        Union $union, 
-        EntityManagerInterface $entityManager, 
-        #[MapEntity(id: 'personId')] Person $person,
+        Request $request,
+        Union $union,
+        EntityManagerInterface $entityManager,
+        #[MapEntity(id: 'personId')]
+        Person $person,
         PersonRepository $personRepository,
     ): Response {
         $form = $this->createForm(UnionType::class, $union);
@@ -78,7 +79,7 @@ class UnionController extends AbstractController
             $entityManager->flush();
 
             $this->addFlash(
-                'success', 
+                'success',
                 $this->translator->trans('union.edit.success')
             );
 
@@ -139,12 +140,12 @@ class UnionController extends AbstractController
             $entityManager->flush();
 
             $this->addFlash(
-                'success', 
+                'success',
                 $this->translator->trans('union.delete.success')
             );
         } else {
             $this->addFlash(
-                'danger', 
+                'danger',
                 $this->translator->trans('union.delete.error')
             );
         }
@@ -169,7 +170,7 @@ class UnionController extends AbstractController
             $union->addPerson($form->get('person')->getData());
             $entityManager->flush();
             $this->addFlash(
-                'success', 
+                'success',
                 $this->translator->trans('union.partner.add.success', ['name' => $person->getFullName()])
             );
         }
@@ -194,7 +195,7 @@ class UnionController extends AbstractController
         if ($this->isCsrfTokenValid('delete'.$partner->getId(), $request->request->get('_token'))) {
             $union->removePerson($partner);
             $this->addFlash(
-                'success', 
+                'success',
                 $this->translator->trans('union.partner.remove.success', ['name' => $partner->getFullName()])
             );
 
@@ -206,7 +207,7 @@ class UnionController extends AbstractController
                 $entityManager->flush();
 
                 $this->addFlash(
-                    'info', 
+                    'info',
                     $this->translator->trans('union.delete.info')
                 );
 
@@ -219,7 +220,7 @@ class UnionController extends AbstractController
             $entityManager->flush();
         } else {
             $this->addFlash(
-                'danger', 
+                'danger',
                 $this->translator->trans('union.partner.remove.error', ['name' => $partner->getFullName()])
             );
         }
@@ -233,9 +234,10 @@ class UnionController extends AbstractController
     #[Route('/person/{personId}/union/{id}/add-child', name: 'app_union_add_child', methods: ['POST'])]
     #[IsGranted('edit', 'union')]
     public function addChild(
-        Request $request, 
-        EntityManagerInterface $entityManager, 
-        #[MapEntity(id: 'personId')] Person $person, 
+        Request $request,
+        EntityManagerInterface $entityManager,
+        #[MapEntity(id: 'personId')]
+        Person $person,
         Union $union,
         PersonRepository $personRepository,
     ): Response {
@@ -252,7 +254,7 @@ class UnionController extends AbstractController
             $union->addChild($form->get('person')->getData());
             $entityManager->flush();
             $this->addFlash(
-                'success', 
+                'success',
                 $this->translator->trans('union.child.add.success', ['name' => $form->get('person')->getData()->getFullName()])
             );
         }
@@ -278,12 +280,12 @@ class UnionController extends AbstractController
             $union->removeChild($child);
             $entityManager->flush();
             $this->addFlash(
-                'success', 
+                'success',
                 $this->translator->trans('union.child.remove.success', ['name' => $child->getFullName()])
             );
         } else {
             $this->addFlash(
-                'danger', 
+                'danger',
                 $this->translator->trans('union.child.remove.error', ['name' => $child->getFullName()])
             );
         }

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -20,7 +20,8 @@ class UnionController extends AbstractController
 {
     public function __construct(
         private TranslatorInterface $translator,
-    ) {}
+    ) {
+    }
 
     #[Route('/person/{personId}/union/new', name: 'app_union_new', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'person')]

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -191,7 +191,7 @@ class UnionController extends AbstractController
         Person $person,
         Union $union,
         #[MapEntity(id: 'partnerId')]
-        Person $partner
+        Person $partner,
     ): Response {
         if ($this->isCsrfTokenValid('delete'.$partner->getId(), $request->request->get('_token'))) {
             $union->removePerson($partner);
@@ -275,7 +275,7 @@ class UnionController extends AbstractController
         Person $person,
         Union $union,
         #[MapEntity(id: 'childId')]
-        Person $child
+        Person $child,
     ): Response {
         if ($this->isCsrfTokenValid('delete'.$child->getId(), $request->request->get('_token'))) {
             $union->removeChild($child);

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -102,8 +102,8 @@ class UnionController extends AbstractController
             ];
         }
 
-        $unionPartners = $union->getPeople();
-        $birthDates = array_map(fn (Person $person): ?\DateTimeInterface => $person->getBirth(), $unionPartners->toArray());
+        $people = $union->getPeople();
+        $birthDates = array_map(fn (Person $person): ?\DateTimeInterface => $person->getBirth(), $people->toArray());
         $birthDates = array_filter($birthDates, fn (?\DateTimeInterface $date): bool => $date instanceof \DateTimeInterface);
 
         $mostRecentBirthDate = count($birthDates) < 1 ? null : max($birthDates);

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -103,8 +103,8 @@ class UnionController extends AbstractController
         }
 
         $unionPartners = $union->getPeople();
-        $birthDates = array_map(fn (Person $person) => $person->getBirth(), $unionPartners->toArray());
-        $birthDates = array_filter($birthDates, fn ($date) => null !== $date);
+        $birthDates = array_map(fn (Person $person): ?\DateTimeInterface => $person->getBirth(), $unionPartners->toArray());
+        $birthDates = array_filter($birthDates, fn ($date): bool => null !== $date);
 
         $mostRecentBirthDate = count($birthDates) < 1 ? null : max($birthDates);
 

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -131,6 +131,7 @@ class UnionController extends AbstractController
             foreach ($union->getPeople() as $person) {
                 $person->removeUnion($union);
             }
+
             foreach ($union->getChildren() as $child) {
                 $union->removeChild($child);
             }
@@ -201,6 +202,7 @@ class UnionController extends AbstractController
                 foreach ($union->getChildren() as $child) {
                     $union->removeChild($child);
                 }
+
                 $this->entityManager->remove($union);
                 $this->entityManager->flush();
 

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -104,7 +104,7 @@ class UnionController extends AbstractController
 
         $unionPartners = $union->getPeople();
         $birthDates = array_map(fn (Person $person): ?\DateTimeInterface => $person->getBirth(), $unionPartners->toArray());
-        $birthDates = array_filter($birthDates, fn (?\DateTimeInterface $date): bool => null !== $date);
+        $birthDates = array_filter($birthDates, fn (?\DateTimeInterface $date): bool => $date instanceof \DateTimeInterface);
 
         $mostRecentBirthDate = count($birthDates) < 1 ? null : max($birthDates);
 

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -105,8 +105,8 @@ class UnionController extends AbstractController
         }
 
         $unionPartners = $union->getPeople();
-        $birthDates = array_map(fn(Person $person) => $person->getBirth(), $unionPartners->toArray());
-        $birthDates = array_filter($birthDates, fn($date) => $date !== null);
+        $birthDates = array_map(fn (Person $person) => $person->getBirth(), $unionPartners->toArray());
+        $birthDates = array_filter($birthDates, fn ($date) => $date !== null);
         $mostRecentBirthDate = count($birthDates) < 1 ? null : max($birthDates);
 
         return $this->render('union/edit.html.twig', [

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -106,7 +106,7 @@ class UnionController extends AbstractController
 
         $unionPartners = $union->getPeople();
         $birthDates = array_map(fn (Person $person) => $person->getBirth(), $unionPartners->toArray());
-        $birthDates = array_filter($birthDates, fn ($date) => $date !== null);
+        $birthDates = array_filter($birthDates, fn ($date) => null !== $date);
         $mostRecentBirthDate = count($birthDates) < 1 ? null : max($birthDates);
 
         return $this->render('union/edit.html.twig', [
@@ -200,7 +200,7 @@ class UnionController extends AbstractController
                 $this->translator->trans('union.partner.remove.success', ['name' => $partner->getFullName()])
             );
 
-            if ($union->getPeople()->count() === 0) {
+            if (0 === $union->getPeople()->count()) {
                 foreach ($union->getChildren() as $child) {
                     $union->removeChild($child);
                 }

--- a/src/Controller/UnionController.php
+++ b/src/Controller/UnionController.php
@@ -19,13 +19,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class UnionController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator,
+        private readonly TranslatorInterface $translator, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager, private readonly \App\Repository\PersonRepository $personRepository,
     ) {
     }
 
     #[Route('/person/{personId}/union/new', name: 'app_union_new', methods: ['GET', 'POST'])]
     #[IsGranted('edit', 'person')]
-    public function new(Request $request, EntityManagerInterface $entityManager, #[MapEntity(id: 'personId')] Person $person): Response
+    public function new(Request $request, #[MapEntity(id: 'personId')] Person $person): Response
     {
         $union = new Union();
         $form = $this->createForm(UnionType::class, $union);
@@ -33,8 +33,8 @@ class UnionController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $person->addUnion($union);
-            $entityManager->persist($union);
-            $entityManager->flush();
+            $this->entityManager->persist($union);
+            $this->entityManager->flush();
 
             $this->addFlash(
                 'success',
@@ -68,16 +68,14 @@ class UnionController extends AbstractController
     public function edit(
         Request $request,
         Union $union,
-        EntityManagerInterface $entityManager,
         #[MapEntity(id: 'personId')]
         Person $person,
-        PersonRepository $personRepository,
     ): Response {
         $form = $this->createForm(UnionType::class, $union);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $entityManager->flush();
+            $this->entityManager->flush();
 
             $this->addFlash(
                 'success',
@@ -118,7 +116,7 @@ class UnionController extends AbstractController
                 'union_members' => $membersToExclude,
             ]),
             'child_form' => $this->createForm(PersonSelectType::class, null, [
-                'available_members' => $personRepository->getOrphanMembers($person->getTree(), $mostRecentBirthDate),
+                'available_members' => $this->personRepository->getOrphanMembers($person->getTree(), $mostRecentBirthDate),
                 'union_members' => $membersToExclude,
             ]),
         ]);
@@ -126,7 +124,7 @@ class UnionController extends AbstractController
 
     #[Route('/person/{personId}/union/{id}', name: 'app_union_delete', methods: ['POST'])]
     #[IsGranted('delete', 'union')]
-    public function delete(Request $request, Union $union, EntityManagerInterface $entityManager, #[MapEntity(id: 'personId')] Person $person): Response
+    public function delete(Request $request, Union $union, #[MapEntity(id: 'personId')] Person $person): Response
     {
         if ($this->isCsrfTokenValid('delete'.$union->getId(), $request->request->get('_token'))) {
             // First, remove the union from all people
@@ -137,8 +135,8 @@ class UnionController extends AbstractController
                 $union->removeChild($child);
             }
 
-            $entityManager->remove($union);
-            $entityManager->flush();
+            $this->entityManager->remove($union);
+            $this->entityManager->flush();
 
             $this->addFlash(
                 'success',
@@ -156,7 +154,7 @@ class UnionController extends AbstractController
 
     #[Route('/person/{personId}/union/{id}/add-partner', name: 'app_union_add_partner', methods: ['POST'])]
     #[IsGranted('edit', 'union')]
-    public function addPartner(Request $request, EntityManagerInterface $entityManager, #[MapEntity(id: 'personId')] Person $person, Union $union): Response
+    public function addPartner(Request $request, #[MapEntity(id: 'personId')] Person $person, Union $union): Response
     {
         $form = $this->createForm(PersonSelectType::class, null, [
             'available_members' => $person->getTree()->getMembers()->toArray(),
@@ -169,7 +167,7 @@ class UnionController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $union->addPerson($form->get('person')->getData());
-            $entityManager->flush();
+            $this->entityManager->flush();
             $this->addFlash(
                 'success',
                 $this->translator->trans('union.partner.add.success', ['name' => $person->getFullName()])
@@ -186,7 +184,6 @@ class UnionController extends AbstractController
     #[IsGranted('edit', 'union')]
     public function removePartner(
         Request $request,
-        EntityManagerInterface $entityManager,
         #[MapEntity(id: 'personId')]
         Person $person,
         Union $union,
@@ -204,8 +201,8 @@ class UnionController extends AbstractController
                 foreach ($union->getChildren() as $child) {
                     $union->removeChild($child);
                 }
-                $entityManager->remove($union);
-                $entityManager->flush();
+                $this->entityManager->remove($union);
+                $this->entityManager->flush();
 
                 $this->addFlash(
                     'info',
@@ -218,7 +215,7 @@ class UnionController extends AbstractController
                 ], Response::HTTP_SEE_OTHER);
             }
 
-            $entityManager->flush();
+            $this->entityManager->flush();
         } else {
             $this->addFlash(
                 'danger',
@@ -236,14 +233,12 @@ class UnionController extends AbstractController
     #[IsGranted('edit', 'union')]
     public function addChild(
         Request $request,
-        EntityManagerInterface $entityManager,
         #[MapEntity(id: 'personId')]
         Person $person,
         Union $union,
-        PersonRepository $personRepository,
     ): Response {
         $form = $this->createForm(PersonSelectType::class, null, [
-            'available_members' => $personRepository->getOrphanMembers($person->getTree()),
+            'available_members' => $this->personRepository->getOrphanMembers($person->getTree()),
             'union_members' => [
                 ...$union->getPeople()->toArray(),
                 ...$union->getChildren()->toArray(),
@@ -253,7 +248,7 @@ class UnionController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $union->addChild($form->get('person')->getData());
-            $entityManager->flush();
+            $this->entityManager->flush();
             $this->addFlash(
                 'success',
                 $this->translator->trans('union.child.add.success', ['name' => $form->get('person')->getData()->getFullName()])
@@ -270,7 +265,6 @@ class UnionController extends AbstractController
     #[IsGranted('edit', 'union')]
     public function removeChild(
         Request $request,
-        EntityManagerInterface $entityManager,
         #[MapEntity(id: 'personId')]
         Person $person,
         Union $union,
@@ -279,7 +273,7 @@ class UnionController extends AbstractController
     ): Response {
         if ($this->isCsrfTokenValid('delete'.$child->getId(), $request->request->get('_token'))) {
             $union->removeChild($child);
-            $entityManager->flush();
+            $this->entityManager->flush();
             $this->addFlash(
                 'success',
                 $this->translator->trans('union.child.remove.success', ['name' => $child->getFullName()])

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class UserController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager, private readonly \Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface $passwordHasher,
+        private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager, private readonly UserPasswordHasherInterface $passwordHasher,
     ) {
     }
 

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -20,6 +20,7 @@ class UserController extends AbstractController
         private readonly TranslatorInterface $translator, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager, private readonly \Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface $passwordHasher,
     ) {
     }
+
     #[Route('/profile/', name: 'app_user_edit', methods: ['GET', 'POST'])]
     public function edit(Request $request, #[CurrentUser()] User $user): Response
     {
@@ -42,6 +43,7 @@ class UserController extends AbstractController
             'form' => $form,
         ]);
     }
+
     #[Route('/profile/{id}', name: 'app_user_delete', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
     public function delete(Request $request, User $user): Response

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class UserController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager, private readonly UserPasswordHasherInterface $passwordHasher,
+        private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager, private readonly UserPasswordHasherInterface $userPasswordHasher,
     ) {
     }
 
@@ -29,7 +29,7 @@ class UserController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             if ($plainPassword = $form->get('password')->getData()) {
-                $user->setPassword($this->passwordHasher->hashPassword($user, $plainPassword));
+                $user->setPassword($this->userPasswordHasher->hashPassword($user, $plainPassword));
             }
 
             $this->addFlash(

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -14,15 +14,13 @@ use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[Route('/profile')]
 class UserController extends AbstractController
 {
     public function __construct(
         private readonly TranslatorInterface $translator,
     ) {
     }
-
-    #[Route('/', name: 'app_user_edit', methods: ['GET', 'POST'])]
+    #[Route('/profile/', name: 'app_user_edit', methods: ['GET', 'POST'])]
     public function edit(Request $request, #[CurrentUser()] User $user, EntityManagerInterface $entityManager, UserPasswordHasherInterface $passwordHasher): Response
     {
         $form = $this->createForm(UserType::class, $user);
@@ -44,8 +42,7 @@ class UserController extends AbstractController
             'form' => $form,
         ]);
     }
-
-    #[Route('/{id}', name: 'app_user_delete', methods: ['POST'])]
+    #[Route('/profile/{id}', name: 'app_user_delete', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
     public function delete(Request $request, User $user, EntityManagerInterface $entityManager): Response
     {

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -19,7 +19,8 @@ class UserController extends AbstractController
 {
     public function __construct(
         private TranslatorInterface $translator,
-    ) {}
+    ) {
+    }
 
     #[Route('/', name: 'app_user_edit', methods: ['GET', 'POST'])]
     public function edit(Request $request, #[CurrentUser()] User $user, EntityManagerInterface $entityManager, UserPasswordHasherInterface $passwordHasher): Response

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -31,6 +31,7 @@ class UserController extends AbstractController
             if ($plainPassword = $form->get('password')->getData()) {
                 $user->setPassword($this->passwordHasher->hashPassword($user, $plainPassword));
             }
+
             $this->addFlash(
                 'success',
                 $this->translator->trans('profile.edit.success')

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -17,24 +17,24 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class UserController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator,
+        private readonly TranslatorInterface $translator, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager, private readonly \Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface $passwordHasher,
     ) {
     }
     #[Route('/profile/', name: 'app_user_edit', methods: ['GET', 'POST'])]
-    public function edit(Request $request, #[CurrentUser()] User $user, EntityManagerInterface $entityManager, UserPasswordHasherInterface $passwordHasher): Response
+    public function edit(Request $request, #[CurrentUser()] User $user): Response
     {
         $form = $this->createForm(UserType::class, $user);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
             if ($plainPassword = $form->get('password')->getData()) {
-                $user->setPassword($passwordHasher->hashPassword($user, $plainPassword));
+                $user->setPassword($this->passwordHasher->hashPassword($user, $plainPassword));
             }
             $this->addFlash(
                 'success',
                 $this->translator->trans('profile.edit.success')
             );
-            $entityManager->flush();
+            $this->entityManager->flush();
         }
 
         return $this->render('user/edit.html.twig', [
@@ -44,11 +44,11 @@ class UserController extends AbstractController
     }
     #[Route('/profile/{id}', name: 'app_user_delete', methods: ['POST'])]
     #[IsGranted('ROLE_ADMIN')]
-    public function delete(Request $request, User $user, EntityManagerInterface $entityManager): Response
+    public function delete(Request $request, User $user): Response
     {
         if ($this->isCsrfTokenValid('delete'.$user->getId(), $request->request->get('_token'))) {
-            $entityManager->remove($user);
-            $entityManager->flush();
+            $this->entityManager->remove($user);
+            $this->entityManager->flush();
         }
 
         return $this->redirectToRoute('app_user_index', [], Response::HTTP_SEE_OTHER);

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class UserController extends AbstractController
 {
     public function __construct(
-        private TranslatorInterface $translator,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -32,7 +32,7 @@ class UserController extends AbstractController
                 $user->setPassword($passwordHasher->hashPassword($user, $plainPassword));
             }
             $this->addFlash(
-                'success', 
+                'success',
                 $this->translator->trans('profile.edit.success')
             );
             $entityManager->flush();

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -37,7 +37,7 @@ class AppFixtures extends Fixture
         $tree
             ->setOwner($user)
             ->setName('Doe\'s Family')
-            ->setCreatedAt(new DateTimeImmutable())
+            ->setCreatedAt(new \DateTimeImmutable())
         ;
 
         $grandParent1 = new Person();
@@ -48,11 +48,11 @@ class AppFixtures extends Fixture
             ->setBio($faker->paragraph())
             ->setGender(Person::MALE)
 
-            ->setBirth(new DateTimeImmutable('1944-01-02'))
+            ->setBirth(new \DateTimeImmutable('1944-01-02'))
             ->setBirthPlace('New York, NY')
 
             ->setDead(true)
-            ->setDeath(new DateTimeImmutable('2010-02-03'))
+            ->setDeath(new \DateTimeImmutable('2010-02-03'))
             ->setDeathPlace('New York, NY')
         ;
 
@@ -64,11 +64,11 @@ class AppFixtures extends Fixture
             ->setBio($faker->paragraph())
             ->setGender(Person::FEMALE)
 
-            ->setBirth(new DateTimeImmutable('1945-02-03'))
+            ->setBirth(new \DateTimeImmutable('1945-02-03'))
             ->setBirthPlace('Washington, DC')
 
             ->setDead(true)
-            ->setDeath(new DateTimeImmutable('2011-03-04'))
+            ->setDeath(new \DateTimeImmutable('2011-03-04'))
             ->setDeathPlace('New York, NY')
         ;
 
@@ -80,11 +80,11 @@ class AppFixtures extends Fixture
             ->setBio($faker->paragraph())
             ->setGender(Person::MALE)
 
-            ->setBirth(new DateTimeImmutable('1944-01-02'))
+            ->setBirth(new \DateTimeImmutable('1944-01-02'))
             ->setBirthPlace('New York, NY')
 
             ->setDead(true)
-            ->setDeath(new DateTimeImmutable('2010-02-03'))
+            ->setDeath(new \DateTimeImmutable('2010-02-03'))
             ->setDeathPlace('New York, NY')
         ;
 
@@ -96,11 +96,11 @@ class AppFixtures extends Fixture
             ->setBio($faker->paragraph())
             ->setGender(Person::FEMALE)
 
-            ->setBirth(new DateTimeImmutable('1945-02-03'))
+            ->setBirth(new \DateTimeImmutable('1945-02-03'))
             ->setBirthPlace('Washington, DC')
 
             ->setDead(true)
-            ->setDeath(new DateTimeImmutable('2011-03-04'))
+            ->setDeath(new \DateTimeImmutable('2011-03-04'))
             ->setDeathPlace('New York, NY')
         ;
 
@@ -112,7 +112,7 @@ class AppFixtures extends Fixture
             ->setBio($faker->paragraph())
             ->setGender(Person::MALE)
 
-            ->setBirth(new DateTimeImmutable('1970-04-05'))
+            ->setBirth(new \DateTimeImmutable('1970-04-05'))
             ->setBirthPlace('New York, NY')
         ;
 
@@ -124,7 +124,7 @@ class AppFixtures extends Fixture
             ->setBio($faker->paragraph())
             ->setGender(Person::FEMALE)
 
-            ->setBirth(new DateTimeImmutable('1971-06-07'))
+            ->setBirth(new \DateTimeImmutable('1971-06-07'))
             ->setBirthPlace('Washington, DC')
         ;
 
@@ -135,7 +135,7 @@ class AppFixtures extends Fixture
             ->setLastname($parent1->getLastname())
             ->setBio($faker->paragraph())
 
-            ->setBirth(new DateTimeImmutable('1970-04-05'))
+            ->setBirth(new \DateTimeImmutable('1970-04-05'))
             ->setBirthPlace('New York, NY')
         ;
 
@@ -146,7 +146,7 @@ class AppFixtures extends Fixture
             ->setLastname($parent1->getLastname())
             ->setBio($faker->paragraph())
 
-            ->setBirth(new DateTimeImmutable('1971-06-07'))
+            ->setBirth(new \DateTimeImmutable('1971-06-07'))
             ->setBirthPlace('New York, NY')
         ;
 

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -6,7 +6,6 @@ use App\Entity\Person;
 use App\Entity\Tree;
 use App\Entity\Union;
 use App\Entity\User;
-use DateTimeImmutable;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Faker\Factory;

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -47,10 +47,10 @@ class AppFixtures extends Fixture
             ->setLastname($faker->lastName())
             ->setBio($faker->paragraph())
             ->setGender(Person::MALE)
-            
+
             ->setBirth(new DateTimeImmutable('1944-01-02'))
             ->setBirthPlace('New York, NY')
-            
+
             ->setDead(true)
             ->setDeath(new DateTimeImmutable('2010-02-03'))
             ->setDeathPlace('New York, NY')
@@ -63,10 +63,10 @@ class AppFixtures extends Fixture
             ->setLastname($faker->lastName())
             ->setBio($faker->paragraph())
             ->setGender(Person::FEMALE)
-            
+
             ->setBirth(new DateTimeImmutable('1945-02-03'))
             ->setBirthPlace('Washington, DC')
-            
+
             ->setDead(true)
             ->setDeath(new DateTimeImmutable('2011-03-04'))
             ->setDeathPlace('New York, NY')
@@ -79,10 +79,10 @@ class AppFixtures extends Fixture
             ->setLastname($faker->lastName())
             ->setBio($faker->paragraph())
             ->setGender(Person::MALE)
-            
+
             ->setBirth(new DateTimeImmutable('1944-01-02'))
             ->setBirthPlace('New York, NY')
-            
+
             ->setDead(true)
             ->setDeath(new DateTimeImmutable('2010-02-03'))
             ->setDeathPlace('New York, NY')
@@ -95,10 +95,10 @@ class AppFixtures extends Fixture
             ->setLastname($faker->lastName())
             ->setBio($faker->paragraph())
             ->setGender(Person::FEMALE)
-            
+
             ->setBirth(new DateTimeImmutable('1945-02-03'))
             ->setBirthPlace('Washington, DC')
-            
+
             ->setDead(true)
             ->setDeath(new DateTimeImmutable('2011-03-04'))
             ->setDeathPlace('New York, NY')
@@ -111,7 +111,7 @@ class AppFixtures extends Fixture
             ->setLastname($grandParent1->getLastname())
             ->setBio($faker->paragraph())
             ->setGender(Person::MALE)
-            
+
             ->setBirth(new DateTimeImmutable('1970-04-05'))
             ->setBirthPlace('New York, NY')
         ;
@@ -123,7 +123,7 @@ class AppFixtures extends Fixture
             ->setLastname($grandParent3->getLastname())
             ->setBio($faker->paragraph())
             ->setGender(Person::FEMALE)
-            
+
             ->setBirth(new DateTimeImmutable('1971-06-07'))
             ->setBirthPlace('Washington, DC')
         ;
@@ -134,7 +134,7 @@ class AppFixtures extends Fixture
             ->setFirstname($faker->firstNameMale())
             ->setLastname($parent1->getLastname())
             ->setBio($faker->paragraph())
-            
+
             ->setBirth(new DateTimeImmutable('1970-04-05'))
             ->setBirthPlace('New York, NY')
         ;
@@ -145,7 +145,7 @@ class AppFixtures extends Fixture
             ->setFirstname($faker->firstNameFemale())
             ->setLastname($parent1->getLastname())
             ->setBio($faker->paragraph())
-            
+
             ->setBirth(new DateTimeImmutable('1971-06-07'))
             ->setBirthPlace('New York, NY')
         ;

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -20,7 +20,7 @@ class AppFixtures extends Fixture
 
     public function load(ObjectManager $manager): void
     {
-        $faker = Factory::create();
+        $generator = Factory::create();
 
         $user = new User();
         $password = $this->userPasswordHasher->hashPassword($user, 'password');
@@ -42,9 +42,9 @@ class AppFixtures extends Fixture
         $grandParent1 = new Person();
         $grandParent1
             ->setTree($tree)
-            ->setFirstname($faker->firstNameMale())
-            ->setLastname($faker->lastName())
-            ->setBio($faker->paragraph())
+            ->setFirstname($generator->firstNameMale())
+            ->setLastname($generator->lastName())
+            ->setBio($generator->paragraph())
             ->setGender(Person::MALE)
 
             ->setBirth(new \DateTimeImmutable('1944-01-02'))
@@ -58,9 +58,9 @@ class AppFixtures extends Fixture
         $grandParent2 = new Person();
         $grandParent2
             ->setTree($tree)
-            ->setFirstname($faker->firstNameFemale())
-            ->setLastname($faker->lastName())
-            ->setBio($faker->paragraph())
+            ->setFirstname($generator->firstNameFemale())
+            ->setLastname($generator->lastName())
+            ->setBio($generator->paragraph())
             ->setGender(Person::FEMALE)
 
             ->setBirth(new \DateTimeImmutable('1945-02-03'))
@@ -74,9 +74,9 @@ class AppFixtures extends Fixture
         $grandParent3 = new Person();
         $grandParent3
             ->setTree($tree)
-            ->setFirstname($faker->firstNameMale())
-            ->setLastname($faker->lastName())
-            ->setBio($faker->paragraph())
+            ->setFirstname($generator->firstNameMale())
+            ->setLastname($generator->lastName())
+            ->setBio($generator->paragraph())
             ->setGender(Person::MALE)
 
             ->setBirth(new \DateTimeImmutable('1944-01-02'))
@@ -90,9 +90,9 @@ class AppFixtures extends Fixture
         $grandParent4 = new Person();
         $grandParent4
             ->setTree($tree)
-            ->setFirstname($faker->firstNameFemale())
-            ->setLastname($faker->lastName())
-            ->setBio($faker->paragraph())
+            ->setFirstname($generator->firstNameFemale())
+            ->setLastname($generator->lastName())
+            ->setBio($generator->paragraph())
             ->setGender(Person::FEMALE)
 
             ->setBirth(new \DateTimeImmutable('1945-02-03'))
@@ -106,9 +106,9 @@ class AppFixtures extends Fixture
         $parent1 = new Person();
         $parent1
             ->setTree($tree)
-            ->setFirstname($faker->firstNameMale())
+            ->setFirstname($generator->firstNameMale())
             ->setLastname($grandParent1->getLastname())
-            ->setBio($faker->paragraph())
+            ->setBio($generator->paragraph())
             ->setGender(Person::MALE)
 
             ->setBirth(new \DateTimeImmutable('1970-04-05'))
@@ -118,9 +118,9 @@ class AppFixtures extends Fixture
         $parent2 = new Person();
         $parent2
             ->setTree($tree)
-            ->setFirstname($faker->firstNameFemale())
+            ->setFirstname($generator->firstNameFemale())
             ->setLastname($grandParent3->getLastname())
-            ->setBio($faker->paragraph())
+            ->setBio($generator->paragraph())
             ->setGender(Person::FEMALE)
 
             ->setBirth(new \DateTimeImmutable('1971-06-07'))
@@ -130,9 +130,9 @@ class AppFixtures extends Fixture
         $child1 = new Person();
         $child1
             ->setTree($tree)
-            ->setFirstname($faker->firstNameMale())
+            ->setFirstname($generator->firstNameMale())
             ->setLastname($parent1->getLastname())
-            ->setBio($faker->paragraph())
+            ->setBio($generator->paragraph())
 
             ->setBirth(new \DateTimeImmutable('1970-04-05'))
             ->setBirthPlace('New York, NY')
@@ -141,9 +141,9 @@ class AppFixtures extends Fixture
         $child2 = new Person();
         $child2
             ->setTree($tree)
-            ->setFirstname($faker->firstNameFemale())
+            ->setFirstname($generator->firstNameFemale())
             ->setLastname($parent1->getLastname())
-            ->setBio($faker->paragraph())
+            ->setBio($generator->paragraph())
 
             ->setBirth(new \DateTimeImmutable('1971-06-07'))
             ->setBirthPlace('New York, NY')

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -34,7 +34,7 @@ class AppFixtures extends Fixture
 
         $tree = new Tree();
         $tree
-            ->setOwner($user)
+            ->setUser($user)
             ->setName("Doe's Family")
             ->setCreatedAt(new \DateTimeImmutable())
         ;

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -35,7 +35,7 @@ class AppFixtures extends Fixture
         $tree = new Tree();
         $tree
             ->setOwner($user)
-            ->setName('Doe\'s Family')
+            ->setName("Doe's Family")
             ->setCreatedAt(new \DateTimeImmutable())
         ;
 

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use DateTimeInterface;
 use App\Entity\Trait\FormatEmptyStringTrait;
 use App\Repository\PersonRepository;
 use Doctrine\Common\Collections\ArrayCollection;

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -28,7 +28,7 @@ class Person
     #[ORM\Column(length: 30, nullable: true, options: ['default' => ''])]
     private ?string $firstname = null;
 
-    #[ORM\Column(length: 30, nullable: true, options:['default' => ''])]
+    #[ORM\Column(length: 30, nullable: true, options: ['default' => ''])]
     private ?string $lastname = null;
 
     #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: PersonRepository::class)]
-class Person
+class Person implements \Stringable
 {
     use FormatEmptyStringTrait;
 

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -140,7 +140,7 @@ class Person
 
     public function getFullName(): string
     {
-        return trim(mb_strtoupper($this->getDefaultLastname()) . ' ' . $this->firstname);
+        return trim(mb_strtoupper($this->getDefaultLastname()).' '.$this->firstname);
     }
 
     public function getBirth(): ?DateTimeInterface

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -391,7 +391,7 @@ class Person implements \Stringable
     {
         return array_reduce(
             $this->unions->toArray(),
-            fn ($carry, Union $union) => $carry || $union->hasChildren(),
+            fn ($carry, Union $union): bool => $carry || $union->hasChildren(),
             false
         );
     }

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use DateTimeInterface;
 use App\Entity\Trait\FormatEmptyStringTrait;
 use App\Repository\PersonRepository;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -31,10 +32,10 @@ class Person
     private ?string $lastname = null;
 
     #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
-    private ?\DateTimeInterface $birth = null;
+    private ?DateTimeInterface $birth = null;
 
     #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
-    private ?\DateTimeInterface $death = null;
+    private ?DateTimeInterface $death = null;
 
     #[ORM\Column(options: ['default' => false])]
     private ?bool $birthDayUnsure = null;
@@ -152,24 +153,24 @@ class Person
         return trim(mb_strtoupper($this->getDefaultLastname()) . ' ' . $this->firstname);
     }
 
-    public function getBirth(): ?\DateTimeInterface
+    public function getBirth(): ?DateTimeInterface
     {
         return $this->birth;
     }
 
-    public function setBirth(?\DateTimeInterface $birth): static
+    public function setBirth(?DateTimeInterface $birth): static
     {
         $this->birth = $birth;
 
         return $this;
     }
 
-    public function getDeath(): ?\DateTimeInterface
+    public function getDeath(): ?DateTimeInterface
     {
         return $this->death;
     }
 
-    public function setDeath(?\DateTimeInterface $death): static
+    public function setDeath(?DateTimeInterface $death): static
     {
         $this->death = $death;
 

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -16,7 +16,9 @@ class Person implements \Stringable
     use FormatEmptyStringTrait;
 
     public const FEMALE = 0;
+
     public const MALE = 1;
+
     public const OTHER = 2;
 
     #[ORM\Id]

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -427,11 +427,9 @@ class Person
 
     public function removeSource(Source $source): static
     {
-        if ($this->sources->removeElement($source)) {
-            // set the owning side to null (unless already changed)
-            if ($source->getPerson() === $this) {
-                $source->setPerson(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->sources->removeElement($source) && $source->getPerson() === $this) {
+            $source->setPerson(null);
         }
 
         return $this;

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -25,10 +25,10 @@ class Person
     #[ORM\Column]
     private ?int $id = null;
 
-    #[ORM\Column(length: 30, options: ['default' => ''], nullable: true)]
+    #[ORM\Column(length: 30, nullable: true, options: ['default' => ''])]
     private ?string $firstname = null;
 
-    #[ORM\Column(length: 30, options:['default' => ''], nullable: true)]
+    #[ORM\Column(length: 30, nullable: true, options:['default' => ''])]
     private ?string $lastname = null;
 
     #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
@@ -67,7 +67,7 @@ class Person
     #[ORM\ManyToOne(inversedBy: 'children')]
     private ?Union $parentUnion = null;
 
-    #[ORM\ManyToOne(inversedBy: 'members', fetch: 'EAGER')]
+    #[ORM\ManyToOne(fetch: 'EAGER', inversedBy: 'members')]
     #[ORM\JoinColumn(nullable: false)]
     private ?Tree $tree = null;
 
@@ -90,7 +90,7 @@ class Person
     #[ORM\Column(length: 60, nullable: true)]
     private ?string $deathPlace = null;
 
-    #[ORM\OneToMany(mappedBy: 'person', targetEntity: Source::class, orphanRemoval: true)]
+    #[ORM\OneToMany(targetEntity: Source::class, mappedBy: 'person', orphanRemoval: true)]
     private Collection $sources;
 
     public function __construct()

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -38,22 +38,22 @@ class Person
     private ?DateTimeInterface $death = null;
 
     #[ORM\Column(options: ['default' => false])]
-    private ?bool $birthDayUnsure = null;
+    private ?bool $birthDayUnsure = false;
 
     #[ORM\Column(options: ['default' => false])]
-    private ?bool $birthMonthUnsure = null;
+    private ?bool $birthMonthUnsure = false;
 
     #[ORM\Column(options: ['default' => false])]
-    private ?bool $birthYearUnsure = null;
+    private ?bool $birthYearUnsure = false;
 
     #[ORM\Column(options: ['default' => false])]
-    private ?bool $deathDayUnsure = null;
+    private ?bool $deathDayUnsure = false;
 
     #[ORM\Column(options: ['default' => false])]
-    private ?bool $deathMonthUnsure = null;
+    private ?bool $deathMonthUnsure = false;
 
     #[ORM\Column(options: ['default' => false])]
-    private ?bool $deathYearUnsure = null;
+    private ?bool $deathYearUnsure = false;
 
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $portrait = null;
@@ -76,7 +76,7 @@ class Person
     private ?int $gender = null;
 
     #[ORM\Column(options: ['default' => false])]
-    private ?bool $dead = null;
+    private ?bool $dead = false;
 
     #[ORM\Column(length: 30, nullable: true)]
     private ?string $birthName = null;
@@ -97,16 +97,6 @@ class Person
     {
         $this->unions = new ArrayCollection();
         $this->sources = new ArrayCollection();
-
-        $this->birthDayUnsure = false;
-        $this->birthMonthUnsure = false;
-        $this->birthYearUnsure = false;
-
-        $this->deathDayUnsure = false;
-        $this->deathMonthUnsure = false;
-        $this->deathYearUnsure = false;
-
-        $this->dead = false;
     }
 
     public function __toString(): string

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -32,10 +32,10 @@ class Person
     private ?string $lastname = null;
 
     #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
-    private ?DateTimeInterface $birth = null;
+    private ?\DateTimeInterface $birth = null;
 
     #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
-    private ?DateTimeInterface $death = null;
+    private ?\DateTimeInterface $death = null;
 
     #[ORM\Column(options: ['default' => false])]
     private ?bool $birthDayUnsure = false;
@@ -143,24 +143,24 @@ class Person
         return trim(mb_strtoupper($this->getDefaultLastname()).' '.$this->firstname);
     }
 
-    public function getBirth(): ?DateTimeInterface
+    public function getBirth(): ?\DateTimeInterface
     {
         return $this->birth;
     }
 
-    public function setBirth(?DateTimeInterface $birth): static
+    public function setBirth(?\DateTimeInterface $birth): static
     {
         $this->birth = $birth;
 
         return $this;
     }
 
-    public function getDeath(): ?DateTimeInterface
+    public function getDeath(): ?\DateTimeInterface
     {
         return $this->death;
     }
 
-    public function setDeath(?DateTimeInterface $death): static
+    public function setDeath(?\DateTimeInterface $death): static
     {
         $this->death = $death;
 

--- a/src/Entity/Source.php
+++ b/src/Entity/Source.php
@@ -14,10 +14,15 @@ class Source
     use FormatEmptyStringTrait;
 
     public const CERT_BIRTH = 1;
+
     public const CERT_BAPTISM = 2;
+
     public const CERT_MARRIAGE = 3;
+
     public const CERT_DEATH = 4;
+
     public const CERT_MILITARY = 5;
+
     public const CERT_OTHER = 6;
 
     #[ORM\Id]

--- a/src/Entity/Source.php
+++ b/src/Entity/Source.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Source
 {
     use FormatEmptyStringTrait;
-    
+
     public const CERT_BIRTH = 1;
     public const CERT_BAPTISM = 2;
     public const CERT_MARRIAGE = 3;

--- a/src/Entity/Source.php
+++ b/src/Entity/Source.php
@@ -32,7 +32,7 @@ class Source
         self::CERT_MARRIAGE,
         self::CERT_DEATH,
         self::CERT_MILITARY,
-        self::CERT_OTHER
+        self::CERT_OTHER,
     ])]
     private ?int $type = null;
 

--- a/src/Entity/Source.php
+++ b/src/Entity/Source.php
@@ -64,6 +64,9 @@ class Source
         return $this->type;
     }
 
+    /**
+     * @return array<int, string>
+     */
     public function getTypes(): array
     {
         return [

--- a/src/Entity/Trait/FormatEmptyStringTrait.php
+++ b/src/Entity/Trait/FormatEmptyStringTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Entity\Trait;
 
 trait FormatEmptyStringTrait

--- a/src/Entity/Trait/FormatEmptyStringTrait.php
+++ b/src/Entity/Trait/FormatEmptyStringTrait.php
@@ -8,6 +8,6 @@ trait FormatEmptyStringTrait
 {
     public function formatEmptyString(?string $value): ?string
     {
-        return ($value !== null && trim($value) === '') ? null : $value;
+        return (null !== $value && '' === trim($value)) ? null : $value;
     }
 }

--- a/src/Entity/Trait/FormatEmptyStringTrait.php
+++ b/src/Entity/Trait/FormatEmptyStringTrait.php
@@ -8,6 +8,6 @@ trait FormatEmptyStringTrait
 {
     public function formatEmptyString(?string $value): ?string
     {
-        return ($value !== null && strlen(trim($value)) === 0) ? null : $value;
+        return ($value !== null && trim($value) === '') ? null : $value;
     }
 }

--- a/src/Entity/Tree.php
+++ b/src/Entity/Tree.php
@@ -72,11 +72,9 @@ class Tree
 
     public function removeMember(Person $member): static
     {
-        if ($this->members->removeElement($member)) {
-            // set the owning side to null (unless already changed)
-            if ($member->getTree() === $this) {
-                $member->setTree(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->members->removeElement($member) && $member->getTree() === $this) {
+            $member->setTree(null);
         }
 
         return $this;

--- a/src/Entity/Tree.php
+++ b/src/Entity/Tree.php
@@ -39,12 +39,12 @@ class Tree
         return $this->id;
     }
 
-    public function getOwner(): ?User
+    public function getUser(): ?User
     {
         return $this->user;
     }
 
-    public function setOwner(?User $user): static
+    public function setUser(?User $user): static
     {
         $this->user = $user;
 

--- a/src/Entity/Tree.php
+++ b/src/Entity/Tree.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use DateTimeImmutable;
 use App\Repository\TreeRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;

--- a/src/Entity/Tree.php
+++ b/src/Entity/Tree.php
@@ -17,7 +17,7 @@ class Tree
 
     #[ORM\ManyToOne(inversedBy: 'trees')]
     #[ORM\JoinColumn(nullable: false)]
-    private ?User $owner = null;
+    private ?User $user = null;
 
     #[ORM\OneToMany(targetEntity: Person::class, mappedBy: 'tree', orphanRemoval: true)]
     #[ORM\OrderBy(['lastname' => 'ASC', 'firstname' => 'ASC'])]
@@ -41,12 +41,12 @@ class Tree
 
     public function getOwner(): ?User
     {
-        return $this->owner;
+        return $this->user;
     }
 
     public function setOwner(?User $user): static
     {
-        $this->owner = $user;
+        $this->user = $user;
 
         return $this;
     }

--- a/src/Entity/Tree.php
+++ b/src/Entity/Tree.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use DateTimeImmutable;
 use App\Repository\TreeRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -24,7 +25,7 @@ class Tree
     private Collection $members;
 
     #[ORM\Column]
-    private ?\DateTimeImmutable $createdAt = null;
+    private ?DateTimeImmutable $createdAt = null;
 
     #[ORM\Column(length: 30, options: ['default' => 'My family tree'])]
     private ?string $name = null;
@@ -81,12 +82,12 @@ class Tree
         return $this;
     }
 
-    public function getCreatedAt(): ?\DateTimeImmutable
+    public function getCreatedAt(): ?DateTimeImmutable
     {
         return $this->createdAt;
     }
 
-    public function setCreatedAt(\DateTimeImmutable $createdAt): static
+    public function setCreatedAt(DateTimeImmutable $createdAt): static
     {
         $this->createdAt = $createdAt;
 

--- a/src/Entity/Tree.php
+++ b/src/Entity/Tree.php
@@ -25,7 +25,7 @@ class Tree
     private Collection $members;
 
     #[ORM\Column]
-    private ?DateTimeImmutable $createdAt = null;
+    private ?\DateTimeImmutable $createdAt = null;
 
     #[ORM\Column(length: 30, options: ['default' => 'My family tree'])]
     private ?string $name = null;
@@ -80,12 +80,12 @@ class Tree
         return $this;
     }
 
-    public function getCreatedAt(): ?DateTimeImmutable
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
 
-    public function setCreatedAt(DateTimeImmutable $createdAt): static
+    public function setCreatedAt(\DateTimeImmutable $createdAt): static
     {
         $this->createdAt = $createdAt;
 

--- a/src/Entity/Tree.php
+++ b/src/Entity/Tree.php
@@ -20,7 +20,7 @@ class Tree
     #[ORM\JoinColumn(nullable: false)]
     private ?User $owner = null;
 
-    #[ORM\OneToMany(mappedBy: 'tree', targetEntity: Person::class, orphanRemoval: true)]
+    #[ORM\OneToMany(targetEntity: Person::class, mappedBy: 'tree', orphanRemoval: true)]
     #[ORM\OrderBy(['lastname' => 'ASC', 'firstname' => 'ASC'])]
     private Collection $members;
 

--- a/src/Entity/Tree.php
+++ b/src/Entity/Tree.php
@@ -44,9 +44,9 @@ class Tree
         return $this->owner;
     }
 
-    public function setOwner(?User $owner): static
+    public function setOwner(?User $user): static
     {
-        $this->owner = $owner;
+        $this->owner = $user;
 
         return $this;
     }
@@ -59,21 +59,21 @@ class Tree
         return $this->members;
     }
 
-    public function addMember(Person $member): static
+    public function addMember(Person $person): static
     {
-        if (!$this->members->contains($member)) {
-            $this->members->add($member);
-            $member->setTree($this);
+        if (!$this->members->contains($person)) {
+            $this->members->add($person);
+            $person->setTree($this);
         }
 
         return $this;
     }
 
-    public function removeMember(Person $member): static
+    public function removeMember(Person $person): static
     {
         // set the owning side to null (unless already changed)
-        if ($this->members->removeElement($member) && $member->getTree() === $this) {
-            $member->setTree(null);
+        if ($this->members->removeElement($person) && $person->getTree() === $this) {
+            $person->setTree(null);
         }
 
         return $this;

--- a/src/Entity/Union.php
+++ b/src/Entity/Union.php
@@ -2,6 +2,8 @@
 
 namespace App\Entity;
 
+use DateTimeInterface;
+use DateTimeImmutable;
 use App\Entity\Trait\FormatEmptyStringTrait;
 use App\Repository\UnionRepository;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -30,7 +32,7 @@ class Union
     private ?bool $married = null;
 
     #[ORM\Column(type: Types::DATE_IMMUTABLE, nullable: true)]
-    private ?\DateTimeInterface $startsAt = null;
+    private ?DateTimeInterface $startsAt = null;
 
     #[ORM\Column(length: 100, nullable: true)]
     private ?string $place = null;
@@ -48,7 +50,7 @@ class Union
     private ?string $description = null;
 
     #[ORM\Column(nullable: true)]
-    private ?\DateTimeImmutable $endsAt = null;
+    private ?DateTimeImmutable $endsAt = null;
 
     #[ORM\Column(options: ['default' => false])]
     private ?bool $endDayUnsure = null;
@@ -141,12 +143,12 @@ class Union
         return $this;
     }
 
-    public function getStartsAt(): ?\DateTimeImmutable
+    public function getStartsAt(): ?DateTimeImmutable
     {
         return $this->startsAt;
     }
 
-    public function setStartsAt(?\DateTimeImmutable $startsAt): static
+    public function setStartsAt(?DateTimeImmutable $startsAt): static
     {
         $this->startsAt = $startsAt;
 
@@ -229,12 +231,12 @@ class Union
         return null;
     }
 
-    public function getEndsAt(): ?\DateTimeImmutable
+    public function getEndsAt(): ?DateTimeImmutable
     {
         return $this->endsAt;
     }
 
-    public function setEndsAt(?\DateTimeImmutable $endsAt): static
+    public function setEndsAt(?DateTimeImmutable $endsAt): static
     {
         $this->endsAt = $endsAt;
 

--- a/src/Entity/Union.php
+++ b/src/Entity/Union.php
@@ -2,8 +2,6 @@
 
 namespace App\Entity;
 
-use DateTimeInterface;
-use DateTimeImmutable;
 use App\Entity\Trait\FormatEmptyStringTrait;
 use App\Repository\UnionRepository;
 use Doctrine\Common\Collections\ArrayCollection;

--- a/src/Entity/Union.php
+++ b/src/Entity/Union.php
@@ -29,7 +29,7 @@ class Union
     private Collection $children;
 
     #[ORM\Column]
-    private ?bool $married = null;
+    private ?bool $married = false;
 
     #[ORM\Column(type: Types::DATE_IMMUTABLE, nullable: true)]
     private ?DateTimeInterface $startsAt = null;
@@ -38,13 +38,13 @@ class Union
     private ?string $place = null;
 
     #[ORM\Column(options: ['default' => false])]
-    private ?bool $dayUnsure = null;
+    private ?bool $dayUnsure = false;
 
     #[ORM\Column(options: ['default' => false])]
-    private ?bool $monthUnsure = null;
+    private ?bool $monthUnsure = false;
 
     #[ORM\Column(options: ['default' => false])]
-    private ?bool $yearUnsure = null;
+    private ?bool $yearUnsure = false;
 
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $description = null;
@@ -65,11 +65,6 @@ class Union
     {
         $this->people = new ArrayCollection();
         $this->children = new ArrayCollection();
-
-        $this->married = false;
-        $this->dayUnsure = false;
-        $this->monthUnsure = false;
-        $this->yearUnsure = false;
     }
 
     public function getId(): ?int

--- a/src/Entity/Union.php
+++ b/src/Entity/Union.php
@@ -102,21 +102,21 @@ class Union
         return $this->children;
     }
 
-    public function addChild(Person $child): static
+    public function addChild(Person $person): static
     {
-        if (!$this->children->contains($child)) {
-            $this->children->add($child);
-            $child->setParentUnion($this);
+        if (!$this->children->contains($person)) {
+            $this->children->add($person);
+            $person->setParentUnion($this);
         }
 
         return $this;
     }
 
-    public function removeChild(Person $child): static
+    public function removeChild(Person $person): static
     {
         // set the owning side to null (unless already changed)
-        if ($this->children->removeElement($child) && $child->getParentUnion() === $this) {
-            $child->setParentUnion(null);
+        if ($this->children->removeElement($person) && $person->getParentUnion() === $this) {
+            $person->setParentUnion(null);
         }
 
         return $this;

--- a/src/Entity/Union.php
+++ b/src/Entity/Union.php
@@ -116,11 +116,9 @@ class Union
 
     public function removeChild(Person $child): static
     {
-        if ($this->children->removeElement($child)) {
-            // set the owning side to null (unless already changed)
-            if ($child->getParentUnion() === $this) {
-                $child->setParentUnion(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->children->removeElement($child) && $child->getParentUnion() === $this) {
+            $child->setParentUnion(null);
         }
 
         return $this;

--- a/src/Entity/Union.php
+++ b/src/Entity/Union.php
@@ -25,7 +25,7 @@ class Union
     #[ORM\ManyToMany(targetEntity: Person::class, inversedBy: 'unions')]
     private Collection $people;
 
-    #[ORM\OneToMany(mappedBy: 'parentUnion', targetEntity: Person::class)]
+    #[ORM\OneToMany(targetEntity: Person::class, mappedBy: 'parentUnion')]
     private Collection $children;
 
     #[ORM\Column]

--- a/src/Entity/Union.php
+++ b/src/Entity/Union.php
@@ -32,7 +32,7 @@ class Union
     private ?bool $married = false;
 
     #[ORM\Column(type: Types::DATE_IMMUTABLE, nullable: true)]
-    private ?DateTimeInterface $startsAt = null;
+    private ?\DateTimeInterface $startsAt = null;
 
     #[ORM\Column(length: 100, nullable: true)]
     private ?string $place = null;
@@ -50,7 +50,7 @@ class Union
     private ?string $description = null;
 
     #[ORM\Column(nullable: true)]
-    private ?DateTimeImmutable $endsAt = null;
+    private ?\DateTimeImmutable $endsAt = null;
 
     #[ORM\Column(options: ['default' => false])]
     private ?bool $endDayUnsure = null;
@@ -136,12 +136,12 @@ class Union
         return $this;
     }
 
-    public function getStartsAt(): ?DateTimeImmutable
+    public function getStartsAt(): ?\DateTimeImmutable
     {
         return $this->startsAt;
     }
 
-    public function setStartsAt(?DateTimeImmutable $startsAt): static
+    public function setStartsAt(?\DateTimeImmutable $startsAt): static
     {
         $this->startsAt = $startsAt;
 
@@ -224,12 +224,12 @@ class Union
         return null;
     }
 
-    public function getEndsAt(): ?DateTimeImmutable
+    public function getEndsAt(): ?\DateTimeImmutable
     {
         return $this->endsAt;
     }
 
-    public function setEndsAt(?DateTimeImmutable $endsAt): static
+    public function setEndsAt(?\DateTimeImmutable $endsAt): static
     {
         $this->endsAt = $endsAt;
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -167,7 +167,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     {
         if (!$this->trees->contains($tree)) {
             $this->trees->add($tree);
-            $tree->setOwner($this);
+            $tree->setUser($this);
         }
 
         return $this;
@@ -176,8 +176,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function removeTree(Tree $tree): static
     {
         // set the owning side to null (unless already changed)
-        if ($this->trees->removeElement($tree) && $tree->getOwner() === $this) {
-            $tree->setOwner(null);
+        if ($this->trees->removeElement($tree) && $tree->getUser() === $this) {
+            $tree->setUser(null);
         }
 
         return $this;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -41,7 +41,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: 'boolean')]
     private $isVerified = false;
 
-    #[ORM\OneToMany(mappedBy: 'owner', targetEntity: Tree::class, orphanRemoval: true)]
+    #[ORM\OneToMany(targetEntity: Tree::class, mappedBy: 'owner', orphanRemoval: true)]
     private Collection $trees;
 
     public function __construct()

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -175,11 +175,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function removeTree(Tree $tree): static
     {
-        if ($this->trees->removeElement($tree)) {
-            // set the owning side to null (unless already changed)
-            if ($tree->getOwner() === $this) {
-                $tree->setOwner(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->trees->removeElement($tree) && $tree->getOwner() === $this) {
+            $tree->setOwner(null);
         }
 
         return $this;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -38,7 +38,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(length: 30)]
     private ?string $lastname = null;
 
-    #[ORM\Column(type: 'boolean')]
+    #[ORM\Column(type: \Doctrine\DBAL\Types\Types::BOOLEAN)]
     private ?bool $isVerified = false;
 
     #[ORM\OneToMany(targetEntity: Tree::class, mappedBy: 'owner', orphanRemoval: true)]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -39,7 +39,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private ?string $lastname = null;
 
     #[ORM\Column(type: 'boolean')]
-    private $isVerified = false;
+    private ?bool $isVerified = false;
 
     #[ORM\OneToMany(targetEntity: Tree::class, mappedBy: 'owner', orphanRemoval: true)]
     private Collection $trees;

--- a/src/Form/LoginFormType.php
+++ b/src/Form/LoginFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Form;
 
 use Symfony\Component\Form\AbstractType;

--- a/src/Form/MembersSearchType.php
+++ b/src/Form/MembersSearchType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Form;
 
 use Symfony\Component\Form\AbstractType;

--- a/src/Form/MembersSearchType.php
+++ b/src/Form/MembersSearchType.php
@@ -20,7 +20,7 @@ class MembersSearchType extends AbstractType
                     'placeholder' => 'form.placeholder.search_by_name',
                 ],
             ])
-            ->setMethod('GET')
+            ->setMethod(\Symfony\Component\HttpFoundation\Request::METHOD_GET)
         ;
     }
 

--- a/src/Form/PersonSelectType.php
+++ b/src/Form/PersonSelectType.php
@@ -18,8 +18,8 @@ class PersonSelectType extends AbstractType
         $unionMembers = $options['union_members'];
 
         // Prepare the choices
-        $choices = array_udiff($availableMembers, $unionMembers, fn ($a, $b) => $a->getId() <=> $b->getId());
-        usort($choices, fn ($a, $b) => $a->getFullName() <=> $b->getFullName());
+        $choices = array_udiff($availableMembers, $unionMembers, fn ($a, $b): int => $a->getId() <=> $b->getId());
+        usort($choices, fn ($a, $b): int => $a->getFullName() <=> $b->getFullName());
 
         $builder
             ->add('person', EntityType::class, [

--- a/src/Form/PersonSelectType.php
+++ b/src/Form/PersonSelectType.php
@@ -18,8 +18,8 @@ class PersonSelectType extends AbstractType
         $unionMembers = $options['union_members'];
 
         // Prepare the choices
-        $choices = array_udiff($availableMembers, $unionMembers, fn($a, $b) => $a->getId() <=> $b->getId());
-        usort($choices, fn($a, $b) => $a->getFullName() <=> $b->getFullName());
+        $choices = array_udiff($availableMembers, $unionMembers, fn ($a, $b) => $a->getId() <=> $b->getId());
+        usort($choices, fn ($a, $b) => $a->getFullName() <=> $b->getFullName());
 
         $builder
             ->add('person', EntityType::class, [

--- a/src/Form/PersonSelectType.php
+++ b/src/Form/PersonSelectType.php
@@ -18,12 +18,8 @@ class PersonSelectType extends AbstractType
         $unionMembers = $options['union_members'];
 
         // Prepare the choices
-        $choices = array_udiff($availableMembers, $unionMembers, function ($a, $b) {
-            return $a->getId() <=> $b->getId();
-        });
-        usort($choices, function ($a, $b) {
-            return $a->getFullName() <=> $b->getFullName();
-        });
+        $choices = array_udiff($availableMembers, $unionMembers, fn($a, $b) => $a->getId() <=> $b->getId());
+        usort($choices, fn($a, $b) => $a->getFullName() <=> $b->getFullName());
 
         $builder
             ->add('person', EntityType::class, [

--- a/src/Form/PersonType.php
+++ b/src/Form/PersonType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Form;
 
 use App\Entity\Person;

--- a/src/Form/PersonType.php
+++ b/src/Form/PersonType.php
@@ -61,30 +61,30 @@ class PersonType extends AbstractType
                 'required' => false,
                 'label' => 'form.field.uncertain_day',
                 'label_attr' => [
-                    'class' => 'checkbox-inline checkbox-switch'
+                    'class' => 'checkbox-inline checkbox-switch',
                 ],
                 'row_attr' => [
-                    'class' => 'd-inline'
+                    'class' => 'd-inline',
                 ],
             ])
             ->add('birthMonthUnsure', CheckboxType::class, [
                 'required' => false,
                 'label' => 'form.field.uncertain_month',
                 'label_attr' => [
-                    'class' => 'checkbox-inline checkbox-switch'
+                    'class' => 'checkbox-inline checkbox-switch',
                 ],
                 'row_attr' => [
-                    'class' => 'd-inline'
+                    'class' => 'd-inline',
                 ],
             ])
             ->add('birthYearUnsure', CheckboxType::class, [
                 'required' => false,
                 'label' => 'form.field.uncertain_year',
                 'label_attr' => [
-                    'class' => 'checkbox-inline checkbox-switch'
+                    'class' => 'checkbox-inline checkbox-switch',
                 ],
                 'row_attr' => [
-                    'class' => 'd-inline'
+                    'class' => 'd-inline',
                 ],
             ])
             ->add('death', DateType::class, [
@@ -100,40 +100,40 @@ class PersonType extends AbstractType
                 'required' => false,
                 'label' => 'form.field.uncertain_day',
                 'label_attr' => [
-                    'class' => 'checkbox-inline checkbox-switch'
+                    'class' => 'checkbox-inline checkbox-switch',
                 ],
                 'row_attr' => [
-                    'class' => 'd-inline'
+                    'class' => 'd-inline',
                 ],
             ])
             ->add('deathMonthUnsure', CheckboxType::class, [
                 'required' => false,
                 'label' => 'form.field.uncertain_month',
                 'label_attr' => [
-                    'class' => 'checkbox-inline checkbox-switch'
+                    'class' => 'checkbox-inline checkbox-switch',
                 ],
                 'row_attr' => [
-                    'class' => 'd-inline'
+                    'class' => 'd-inline',
                 ],
             ])
             ->add('deathYearUnsure', CheckboxType::class, [
                 'required' => false,
                 'label' => 'form.field.uncertain_year',
                 'label_attr' => [
-                    'class' => 'checkbox-inline checkbox-switch'
+                    'class' => 'checkbox-inline checkbox-switch',
                 ],
                 'row_attr' => [
-                    'class' => 'd-inline'
+                    'class' => 'd-inline',
                 ],
             ])
             ->add('dead', CheckboxType::class, [
                 'required' => false,
                 'label' => 'form.field.deceased',
                 'label_attr' => [
-                    'class' => 'checkbox-inline checkbox-switch'
+                    'class' => 'checkbox-inline checkbox-switch',
                 ],
                 'row_attr' => [
-                    'class' => 'd-inline'
+                    'class' => 'd-inline',
                 ],
             ])
             ->add('gender', ChoiceType::class, [
@@ -145,7 +145,7 @@ class PersonType extends AbstractType
                 ],
                 'expanded' => true,
                 'label_attr' => [
-                    'class' => 'radio-inline'
+                    'class' => 'radio-inline',
                 ],
             ])
         ;

--- a/src/Form/RegistrationFormType.php
+++ b/src/Form/RegistrationFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Form;
 
 use App\Entity\User;

--- a/src/Form/RegistrationFormType.php
+++ b/src/Form/RegistrationFormType.php
@@ -51,9 +51,9 @@ class RegistrationFormType extends AbstractType
                     new NotBlank(message: 'Please enter a password.'),
                     new Length(
                         min: 6,
-                        minMessage: 'Your password should be at least {{ limit }} characters.',
                         // max length allowed by Symfony for security reasons
                         max: 4096,
+                        minMessage: 'Your password should be at least {{ limit }} characters.',
                     ),
                 ],
                 'label' => 'form.field.password',

--- a/src/Form/SourceType.php
+++ b/src/Form/SourceType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Form;
 
 use App\Entity\Source;

--- a/src/Form/TreeOptionsType.php
+++ b/src/Form/TreeOptionsType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Form;
 
 use Symfony\Component\Form\AbstractType;

--- a/src/Form/TreeOptionsType.php
+++ b/src/Form/TreeOptionsType.php
@@ -26,7 +26,7 @@ class TreeOptionsType extends AbstractType
                 'help' => 'form.help.depth',
                 'empty_data' => 4,
             ])
-            ->setMethod('GET')
+            ->setMethod(\Symfony\Component\HttpFoundation\Request::METHOD_GET)
         ;
     }
 

--- a/src/Form/TreeOptionsType.php
+++ b/src/Form/TreeOptionsType.php
@@ -21,7 +21,7 @@ class TreeOptionsType extends AbstractType
                     'min' => 0,
                 ],
                 'constraints' => [
-                    new Assert\PositiveOrZero()
+                    new Assert\PositiveOrZero(),
                 ],
                 'help' => 'form.help.depth',
                 'empty_data' => 4,

--- a/src/Form/TreeType.php
+++ b/src/Form/TreeType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Form;
 
 use App\Entity\Tree;

--- a/src/Form/UnionType.php
+++ b/src/Form/UnionType.php
@@ -41,60 +41,60 @@ class UnionType extends AbstractType
                 'required' => false,
                 'label' => 'form.field.uncertain_day',
                 'label_attr' => [
-                    'class' => 'checkbox-inline checkbox-switch'
+                    'class' => 'checkbox-inline checkbox-switch',
                 ],
                 'row_attr' => [
-                    'class' => 'd-inline'
+                    'class' => 'd-inline',
                 ],
             ])
             ->add('monthUnsure', CheckboxType::class, [
                 'required' => false,
                 'label' => 'form.field.uncertain_month',
                 'label_attr' => [
-                    'class' => 'checkbox-inline checkbox-switch'
+                    'class' => 'checkbox-inline checkbox-switch',
                 ],
                 'row_attr' => [
-                    'class' => 'd-inline'
+                    'class' => 'd-inline',
                 ],
             ])
             ->add('yearUnsure', CheckboxType::class, [
                 'required' => false,
                 'label' => 'form.field.uncertain_year',
                 'label_attr' => [
-                    'class' => 'checkbox-inline checkbox-switch'
+                    'class' => 'checkbox-inline checkbox-switch',
                 ],
                 'row_attr' => [
-                    'class' => 'd-inline'
+                    'class' => 'd-inline',
                 ],
             ])
             ->add('endDayUnsure', CheckboxType::class, [
                 'required' => false,
                 'label' => 'form.field.uncertain_day',
                 'label_attr' => [
-                    'class' => 'checkbox-inline checkbox-switch'
+                    'class' => 'checkbox-inline checkbox-switch',
                 ],
                 'row_attr' => [
-                    'class' => 'd-inline'
+                    'class' => 'd-inline',
                 ],
             ])
             ->add('endMonthUnsure', CheckboxType::class, [
                 'required' => false,
                 'label' => 'form.field.uncertain_month',
                 'label_attr' => [
-                    'class' => 'checkbox-inline checkbox-switch'
+                    'class' => 'checkbox-inline checkbox-switch',
                 ],
                 'row_attr' => [
-                    'class' => 'd-inline'
+                    'class' => 'd-inline',
                 ],
             ])
             ->add('endYearUnsure', CheckboxType::class, [
                 'required' => false,
                 'label' => 'form.field.uncertain_year',
                 'label_attr' => [
-                    'class' => 'checkbox-inline checkbox-switch'
+                    'class' => 'checkbox-inline checkbox-switch',
                 ],
                 'row_attr' => [
-                    'class' => 'd-inline'
+                    'class' => 'd-inline',
                 ],
             ])
             ->add('description', TextareaType::class, [

--- a/src/Form/UnionType.php
+++ b/src/Form/UnionType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Form;
 
 use App\Entity\Union;

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Form;
 
 use App\Entity\User;

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -17,7 +17,7 @@ class UserType extends AbstractType
     {
         $builder
             ->add('email', EmailType::class, [
-                'label' => 'form.field.email'
+                'label' => 'form.field.email',
             ])
             ->add('password', PasswordType::class, [
                 'mapped' => false,
@@ -25,10 +25,10 @@ class UserType extends AbstractType
                 'label' => 'form.field.password',
             ])
             ->add('firstname', null, [
-                'label' => 'form.field.firstname'
+                'label' => 'form.field.firstname',
             ])
             ->add('lastname', null, [
-                'label' => 'form.field.lastname'
+                'label' => 'form.field.lastname',
             ])
         ;
     }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;

--- a/src/Repository/PersonRepository.php
+++ b/src/Repository/PersonRepository.php
@@ -26,7 +26,7 @@ class PersonRepository extends ServiceEntityRepository
     {
         // Select members that are not part of any union
         // and that are born after parents birth date
-        $qb = $this->createQueryBuilder('p')
+        $queryBuilder = $this->createQueryBuilder('p')
             ->leftJoin('p.tree', 't')
             ->leftJoin('p.parentUnion', 'u')
             ->andWhere('t.id = :treeId')
@@ -37,13 +37,13 @@ class PersonRepository extends ServiceEntityRepository
         if ($bornAfter instanceof \DateTime) {
             // If a birth date is provided, select members that are born after it
             // or that have no birth date
-            $qb
+            $queryBuilder
                 ->andWhere('p.birth IS NULL OR p.birth > :bornAfter')
                 ->setParameter('bornAfter', $bornAfter)
             ;
         }
 
-        return $qb
+        return $queryBuilder
             ->getQuery()
             ->getResult()
         ;

--- a/src/Repository/PersonRepository.php
+++ b/src/Repository/PersonRepository.php
@@ -23,7 +23,7 @@ class PersonRepository extends ServiceEntityRepository
         parent::__construct($registry, Person::class);
     }
 
-    public function getOrphanMembers(Tree $tree, ?DateTime $bornAfter = null): array
+    public function getOrphanMembers(Tree $tree, ?\DateTime $bornAfter = null): array
     {
         // Select members that are not part of any union
         // and that are born after parents birth date
@@ -35,7 +35,7 @@ class PersonRepository extends ServiceEntityRepository
             ->setParameter('treeId', $tree->getId())
         ;
 
-        if ($bornAfter instanceof DateTime) {
+        if ($bornAfter instanceof \DateTime) {
             // If a birth date is provided, select members that are born after it
             // or that have no birth date
             $qb

--- a/src/Repository/PersonRepository.php
+++ b/src/Repository/PersonRepository.php
@@ -4,7 +4,6 @@ namespace App\Repository;
 
 use App\Entity\Person;
 use App\Entity\Tree;
-use DateTime;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 

--- a/src/Repository/PersonRepository.php
+++ b/src/Repository/PersonRepository.php
@@ -35,7 +35,7 @@ class PersonRepository extends ServiceEntityRepository
             ->setParameter('treeId', $tree->getId())
         ;
 
-        if ($bornAfter) {
+        if ($bornAfter instanceof DateTime) {
             // If a birth date is provided, select members that are born after it
             // or that have no birth date
             $qb

--- a/src/Repository/SourceRepository.php
+++ b/src/Repository/SourceRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\Source;

--- a/src/Repository/SourceRepository.php
+++ b/src/Repository/SourceRepository.php
@@ -23,28 +23,28 @@ class SourceRepository extends ServiceEntityRepository
         parent::__construct($registry, Source::class);
     }
 
-//    /**
-//     * @return Source[] Returns an array of Source objects
-//     */
-//    public function findByExampleField($value): array
-//    {
-//        return $this->createQueryBuilder('s')
-//            ->andWhere('s.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->orderBy('s.id', 'ASC')
-//            ->setMaxResults(10)
-//            ->getQuery()
-//            ->getResult()
-//        ;
-//    }
+    //    /**
+    //     * @return Source[] Returns an array of Source objects
+    //     */
+    //    public function findByExampleField($value): array
+    //    {
+    //        return $this->createQueryBuilder('s')
+    //            ->andWhere('s.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->orderBy('s.id', 'ASC')
+    //            ->setMaxResults(10)
+    //            ->getQuery()
+    //            ->getResult()
+    //        ;
+    //    }
 
-//    public function findOneBySomeField($value): ?Source
-//    {
-//        return $this->createQueryBuilder('s')
-//            ->andWhere('s.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->getQuery()
-//            ->getOneOrNullResult()
-//        ;
-//    }
+    //    public function findOneBySomeField($value): ?Source
+    //    {
+    //        return $this->createQueryBuilder('s')
+    //            ->andWhere('s.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->getQuery()
+    //            ->getOneOrNullResult()
+    //        ;
+    //    }
 }

--- a/src/Repository/TreeRepository.php
+++ b/src/Repository/TreeRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\Tree;

--- a/src/Repository/UnionRepository.php
+++ b/src/Repository/UnionRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\Union;

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\User;

--- a/src/Security/EmailVerifier.php
+++ b/src/Security/EmailVerifier.php
@@ -15,7 +15,7 @@ class EmailVerifier
     public function __construct(
         private VerifyEmailHelperInterface $verifyEmailHelper,
         private MailerInterface $mailer,
-        private EntityManagerInterface $entityManager
+        private EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/src/Security/EmailVerifier.php
+++ b/src/Security/EmailVerifier.php
@@ -21,16 +21,16 @@ class EmailVerifier
 
     public function sendEmailConfirmation(string $verifyEmailRouteName, User $user, TemplatedEmail $templatedEmail): void
     {
-        $signatureComponents = $this->verifyEmailHelper->generateSignature(
+        $verifyEmailSignatureComponents = $this->verifyEmailHelper->generateSignature(
             $verifyEmailRouteName,
             $user->getId(),
             $user->getEmail()
         );
 
         $context = $templatedEmail->getContext();
-        $context['signedUrl'] = $signatureComponents->getSignedUrl();
-        $context['expiresAtMessageKey'] = $signatureComponents->getExpirationMessageKey();
-        $context['expiresAtMessageData'] = $signatureComponents->getExpirationMessageData();
+        $context['signedUrl'] = $verifyEmailSignatureComponents->getSignedUrl();
+        $context['expiresAtMessageKey'] = $verifyEmailSignatureComponents->getExpirationMessageKey();
+        $context['expiresAtMessageData'] = $verifyEmailSignatureComponents->getExpirationMessageData();
 
         $templatedEmail->context($context);
 

--- a/src/Security/EmailVerifier.php
+++ b/src/Security/EmailVerifier.php
@@ -13,9 +13,9 @@ use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 class EmailVerifier
 {
     public function __construct(
-        private VerifyEmailHelperInterface $verifyEmailHelper,
-        private MailerInterface $mailer,
-        private EntityManagerInterface $entityManager,
+        private readonly VerifyEmailHelperInterface $verifyEmailHelper,
+        private readonly MailerInterface $mailer,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/src/Security/EmailVerifier.php
+++ b/src/Security/EmailVerifier.php
@@ -19,7 +19,7 @@ class EmailVerifier
     ) {
     }
 
-    public function sendEmailConfirmation(string $verifyEmailRouteName, User $user, TemplatedEmail $email): void
+    public function sendEmailConfirmation(string $verifyEmailRouteName, User $user, TemplatedEmail $templatedEmail): void
     {
         $signatureComponents = $this->verifyEmailHelper->generateSignature(
             $verifyEmailRouteName,
@@ -27,14 +27,14 @@ class EmailVerifier
             $user->getEmail()
         );
 
-        $context = $email->getContext();
+        $context = $templatedEmail->getContext();
         $context['signedUrl'] = $signatureComponents->getSignedUrl();
         $context['expiresAtMessageKey'] = $signatureComponents->getExpirationMessageKey();
         $context['expiresAtMessageData'] = $signatureComponents->getExpirationMessageData();
 
-        $email->context($context);
+        $templatedEmail->context($context);
 
-        $this->mailer->send($email);
+        $this->mailer->send($templatedEmail);
     }
 
     /**

--- a/src/Security/Voter/PersonVoter.php
+++ b/src/Security/Voter/PersonVoter.php
@@ -12,7 +12,9 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class PersonVoter extends Voter
 {
     public const EDIT = 'edit';
+
     public const VIEW = 'view';
+
     public const DELETE = 'delete';
 
     protected function supports(string $attribute, mixed $subject): bool

--- a/src/Security/Voter/PersonVoter.php
+++ b/src/Security/Voter/PersonVoter.php
@@ -44,7 +44,7 @@ class PersonVoter extends Voter
 
     private function isOwner(Person $person, User $user): bool
     {
-        return $user === $person->getTree()->getOwner();
+        return $user === $person->getTree()->getUser();
     }
 
     private function canEdit(Person $person, User $user): bool

--- a/src/Security/Voter/PersonVoter.php
+++ b/src/Security/Voter/PersonVoter.php
@@ -18,7 +18,7 @@ class PersonVoter extends Voter
     protected function supports(string $attribute, mixed $subject): bool
     {
         return in_array($attribute, [self::EDIT, self::VIEW, self::DELETE])
-            && $subject instanceof \App\Entity\Person;
+            && $subject instanceof Person;
     }
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool

--- a/src/Security/Voter/PersonVoter.php
+++ b/src/Security/Voter/PersonVoter.php
@@ -19,7 +19,7 @@ class PersonVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        return in_array($attribute, [self::EDIT, self::VIEW, self::DELETE])
+        return in_array($attribute, [self::EDIT, self::VIEW, self::DELETE], true)
             && $subject instanceof Person;
     }
 

--- a/src/Security/Voter/PersonVoter.php
+++ b/src/Security/Voter/PersonVoter.php
@@ -31,19 +31,12 @@ class PersonVoter extends Voter
 
         /** @var Person */
         $person = $subject;
-
-        switch ($attribute) {
-            case self::EDIT:
-                return $this->canEdit($person, $user);
-
-            case self::VIEW:
-                return $this->canView($person, $user);
-
-            case self::DELETE:
-                return $this->canDelete($person, $user);
-        }
-
-        return false;
+        return match ($attribute) {
+            self::EDIT => $this->canEdit($person, $user),
+            self::VIEW => $this->canView($person, $user),
+            self::DELETE => $this->canDelete($person, $user),
+            default => false,
+        };
     }
 
     private function isOwner(Person $person, User $user): bool

--- a/src/Security/Voter/PersonVoter.php
+++ b/src/Security/Voter/PersonVoter.php
@@ -31,6 +31,7 @@ class PersonVoter extends Voter
 
         /** @var Person */
         $person = $subject;
+
         return match ($attribute) {
             self::EDIT => $this->canEdit($person, $user),
             self::VIEW => $this->canView($person, $user),

--- a/src/Security/Voter/TreeVoter.php
+++ b/src/Security/Voter/TreeVoter.php
@@ -32,6 +32,7 @@ class TreeVoter extends Voter
 
         /** @var Tree */
         $tree = $subject;
+
         return match ($attribute) {
             self::EDIT => $this->canEdit($tree, $user),
             self::VIEW => $this->canView($tree, $user),

--- a/src/Security/Voter/TreeVoter.php
+++ b/src/Security/Voter/TreeVoter.php
@@ -21,7 +21,7 @@ class TreeVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        return in_array($attribute, [self::EDIT, self::VIEW, self::DELETE, self::ADD_MEMBER])
+        return in_array($attribute, [self::EDIT, self::VIEW, self::DELETE, self::ADD_MEMBER], true)
             && $subject instanceof Tree;
     }
 

--- a/src/Security/Voter/TreeVoter.php
+++ b/src/Security/Voter/TreeVoter.php
@@ -12,8 +12,11 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class TreeVoter extends Voter
 {
     public const EDIT = 'edit';
+
     public const VIEW = 'view';
+
     public const DELETE = 'delete';
+
     public const ADD_MEMBER = 'add_member';
 
     protected function supports(string $attribute, mixed $subject): bool

--- a/src/Security/Voter/TreeVoter.php
+++ b/src/Security/Voter/TreeVoter.php
@@ -32,22 +32,13 @@ class TreeVoter extends Voter
 
         /** @var Tree */
         $tree = $subject;
-
-        switch ($attribute) {
-            case self::EDIT:
-                return $this->canEdit($tree, $user);
-
-            case self::VIEW:
-                return $this->canView($tree, $user);
-
-            case self::DELETE:
-                return $this->canDelete($tree, $user);
-
-            case self::ADD_MEMBER:
-                return $this->canAddMember($tree, $user);
-        }
-
-        return false;
+        return match ($attribute) {
+            self::EDIT => $this->canEdit($tree, $user),
+            self::VIEW => $this->canView($tree, $user),
+            self::DELETE => $this->canDelete($tree, $user),
+            self::ADD_MEMBER => $this->canAddMember($tree, $user),
+            default => false,
+        };
     }
 
     private function isOwner(Tree $tree, User $user): bool

--- a/src/Security/Voter/TreeVoter.php
+++ b/src/Security/Voter/TreeVoter.php
@@ -47,7 +47,7 @@ class TreeVoter extends Voter
 
     private function isOwner(Tree $tree, User $user): bool
     {
-        return $user === $tree->getOwner();
+        return $user === $tree->getUser();
     }
 
     private function canEdit(Tree $tree, User $user): bool

--- a/src/Security/Voter/TreeVoter.php
+++ b/src/Security/Voter/TreeVoter.php
@@ -19,7 +19,7 @@ class TreeVoter extends Voter
     protected function supports(string $attribute, mixed $subject): bool
     {
         return in_array($attribute, [self::EDIT, self::VIEW, self::DELETE, self::ADD_MEMBER])
-            && $subject instanceof \App\Entity\Tree;
+            && $subject instanceof Tree;
     }
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool

--- a/src/Security/Voter/UnionVoter.php
+++ b/src/Security/Voter/UnionVoter.php
@@ -44,7 +44,7 @@ class UnionVoter extends Voter
 
     private function isOwner(Union $union, User $user): bool
     {
-        return $user === $union->getPeople()[0]->getTree()->getOwner();
+        return $user === $union->getPeople()[0]->getTree()->getUser();
     }
 
     private function canEdit(Union $union, User $user): bool

--- a/src/Security/Voter/UnionVoter.php
+++ b/src/Security/Voter/UnionVoter.php
@@ -18,7 +18,7 @@ class UnionVoter extends Voter
     protected function supports(string $attribute, mixed $subject): bool
     {
         return in_array($attribute, [self::EDIT, self::VIEW, self::DELETE])
-            && $subject instanceof \App\Entity\Union;
+            && $subject instanceof Union;
     }
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool

--- a/src/Security/Voter/UnionVoter.php
+++ b/src/Security/Voter/UnionVoter.php
@@ -31,6 +31,7 @@ class UnionVoter extends Voter
 
         /** @var Union */
         $union = $subject;
+
         return match ($attribute) {
             self::EDIT => $this->canEdit($union, $user),
             self::VIEW => $this->canView($union, $user),

--- a/src/Security/Voter/UnionVoter.php
+++ b/src/Security/Voter/UnionVoter.php
@@ -12,7 +12,9 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class UnionVoter extends Voter
 {
     public const EDIT = 'edit';
+
     public const VIEW = 'view';
+
     public const DELETE = 'delete';
 
     protected function supports(string $attribute, mixed $subject): bool

--- a/src/Security/Voter/UnionVoter.php
+++ b/src/Security/Voter/UnionVoter.php
@@ -19,7 +19,7 @@ class UnionVoter extends Voter
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        return in_array($attribute, [self::EDIT, self::VIEW, self::DELETE])
+        return in_array($attribute, [self::EDIT, self::VIEW, self::DELETE], true)
             && $subject instanceof Union;
     }
 

--- a/src/Security/Voter/UnionVoter.php
+++ b/src/Security/Voter/UnionVoter.php
@@ -31,19 +31,12 @@ class UnionVoter extends Voter
 
         /** @var Union */
         $union = $subject;
-
-        switch ($attribute) {
-            case self::EDIT:
-                return $this->canEdit($union, $user);
-
-            case self::VIEW:
-                return $this->canView($union, $user);
-
-            case self::DELETE:
-                return $this->canDelete($union, $user);
-        }
-
-        return false;
+        return match ($attribute) {
+            self::EDIT => $this->canEdit($union, $user),
+            self::VIEW => $this->canView($union, $user),
+            self::DELETE => $this->canDelete($union, $user),
+            default => false,
+        };
     }
 
     private function isOwner(Union $union, User $user): bool

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -13,7 +13,7 @@ class ImageManager
 {
     public function __construct(
         private readonly SluggerInterface $slugger,
-        private readonly ParameterBagInterface $params,
+        private readonly ParameterBagInterface $parameterBag,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -26,7 +26,7 @@ class ImageManager
 
         try {
             $uploadedFile->move(
-                $this->params->get('portraits_directory'),
+                $this->parameterBag->get('portraits_directory'),
                 $newFilename
             );
         } catch (FileException $fileException) {
@@ -45,7 +45,7 @@ class ImageManager
 
     public function remove(string $filename): void
     {
-        $filePath = $this->params->get('portraits_directory').'/'.$filename;
+        $filePath = $this->parameterBag->get('portraits_directory').'/'.$filename;
 
         if (file_exists($filePath)) {
             try {

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -56,7 +56,7 @@ class ImageManager
                 // $this->flashBag->add('danger', 'An error occurred while removing the image.');
             }
         }
-            // $this->flashBag->add('warning', 'The image does not exist.');
+        // $this->flashBag->add('warning', 'The image does not exist.');
         
     }
 }

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Service;
 
+use Exception;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
@@ -49,7 +50,7 @@ class ImageManager
         if (file_exists($filePath)) {
             try {
                 unlink($filePath);
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $this->logger->error($e->getMessage());
                 // $this->flashBag->add('danger', 'An error occurred while removing the image.');
             }

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -29,8 +29,8 @@ class ImageManager
                 $this->params->get('portraits_directory'),
                 $newFilename
             );
-        } catch (FileException $e) {
-            $this->logger->error($e->getMessage());
+        } catch (FileException $fileException) {
+            $this->logger->error($fileException->getMessage());
         }
 
         return $newFilename;

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -23,7 +23,7 @@ class ImageManager
     {
         $originalFilename = pathinfo($uploadedFile->getClientOriginalName(), PATHINFO_FILENAME);
         $safeFilename = $this->slugger->slug($originalFilename);
-        $newFilename = $safeFilename . '-' . uniqid() . '.' . $uploadedFile->guessClientExtension();
+        $newFilename = $safeFilename.'-'.uniqid().'.'.$uploadedFile->guessClientExtension();
 
         try {
             $uploadedFile->move(
@@ -45,7 +45,7 @@ class ImageManager
 
     public function remove(string $filename)
     {
-        $filePath = $this->params->get('portraits_directory') . '/' . $filename;
+        $filePath = $this->params->get('portraits_directory').'/'.$filename;
 
         if (file_exists($filePath)) {
             try {

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -2,7 +2,6 @@
 
 namespace App\Service;
 
-use Exception;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -55,6 +55,7 @@ class ImageManager
                 // $this->flashBag->add('danger', 'An error occurred while removing the image.');
             }
         }
+
         // $this->flashBag->add('warning', 'The image does not exist.');
     }
 }

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -55,7 +55,7 @@ class ImageManager
                 $this->logger->error($e->getMessage());
                 // $this->flashBag->add('danger', 'An error occurred while removing the image.');
             }
-        }  
+        }
             // $this->flashBag->add('warning', 'The image does not exist.');
         
     }

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -55,8 +55,8 @@ class ImageManager
                 $this->logger->error($e->getMessage());
                 // $this->flashBag->add('danger', 'An error occurred while removing the image.');
             }
-        } else {
+        }  
             // $this->flashBag->add('warning', 'The image does not exist.');
-        }
+        
     }
 }

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -51,7 +51,7 @@ class ImageManager
         if (file_exists($filePath)) {
             try {
                 unlink($filePath);
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 $this->logger->error($e->getMessage());
                 // $this->flashBag->add('danger', 'An error occurred while removing the image.');
             }

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -43,7 +43,7 @@ class ImageManager
         return $this->save($uploadedFile);
     }
 
-    public function remove(string $filename)
+    public function remove(string $filename): void
     {
         $filePath = $this->params->get('portraits_directory').'/'.$filename;
 

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -56,6 +56,5 @@ class ImageManager
             }
         }
         // $this->flashBag->add('warning', 'The image does not exist.');
-
     }
 }

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -21,8 +21,8 @@ class ImageManager
     public function save(UploadedFile $uploadedFile, ?Request $request = null): ?string
     {
         $originalFilename = pathinfo($uploadedFile->getClientOriginalName(), PATHINFO_FILENAME);
-        $safeFilename = $this->slugger->slug($originalFilename);
-        $newFilename = $safeFilename.'-'.uniqid().'.'.$uploadedFile->guessClientExtension();
+        $unicodeString = $this->slugger->slug($originalFilename);
+        $newFilename = $unicodeString.'-'.uniqid().'.'.$uploadedFile->guessClientExtension();
 
         try {
             $uploadedFile->move(

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -40,6 +40,7 @@ class ImageManager
     public function update(string $oldFilename, UploadedFile $uploadedFile): ?string
     {
         $this->remove($oldFilename);
+
         return $this->save($uploadedFile);
     }
 

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -56,6 +56,6 @@ class ImageManager
             }
         }
         // $this->flashBag->add('warning', 'The image does not exist.');
-        
+
     }
 }

--- a/src/Service/ImageManager.php
+++ b/src/Service/ImageManager.php
@@ -12,9 +12,9 @@ use Symfony\Component\String\Slugger\SluggerInterface;
 class ImageManager
 {
     public function __construct(
-        private SluggerInterface $slugger,
-        private ParameterBagInterface $params,
-        private LoggerInterface $logger,
+        private readonly SluggerInterface $slugger,
+        private readonly ParameterBagInterface $params,
+        private readonly LoggerInterface $logger,
     ) {
     }
 

--- a/symfony.lock
+++ b/symfony.lock
@@ -47,6 +47,27 @@
             "migrations/.gitignore"
         ]
     },
+    "friendsofphp/php-cs-fixer": {
+        "version": "3.95",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.39",
+            "ref": "97aaf9026490db73b86c23d49e5774bc89d2b232"
+        },
+        "files": [
+            ".php-cs-fixer.dist.php"
+        ]
+    },
+    "phpstan/phpstan": {
+        "version": "2.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "5e490cc197fb6bb1ae22e5abbc531ddc633b6767"
+        }
+    },
     "phpunit/phpunit": {
         "version": "9.6",
         "recipe": {

--- a/tests/Controller/PersonControllerTest.php
+++ b/tests/Controller/PersonControllerTest.php
@@ -75,27 +75,27 @@ class PersonControllerTest extends WebTestCase
     public function testShow(): void
     {
         $this->markTestIncomplete();
-        $fixture = new Person();
-        $fixture->setFirstname('My Title');
-        $fixture->setLastname('My Title');
-        $fixture->setBirth('My Title');
-        $fixture->setDeath('My Title');
-        $fixture->setBirthDaySure('My Title');
-        $fixture->setBirthMonthSure('My Title');
-        $fixture->setBirthYearSure('My Title');
-        $fixture->setDeathDaySure('My Title');
-        $fixture->setDeathMonthSure('My Title');
-        $fixture->setDeathYearSure('My Title');
-        $fixture->setPortrait('My Title');
-        $fixture->setBio('My Title');
-        $fixture->setUnions('My Title');
-        $fixture->setParentUnion('My Title');
-        $fixture->setTree('My Title');
+        $person = new Person();
+        $person->setFirstname('My Title');
+        $person->setLastname('My Title');
+        $person->setBirth('My Title');
+        $person->setDeath('My Title');
+        $person->setBirthDaySure('My Title');
+        $person->setBirthMonthSure('My Title');
+        $person->setBirthYearSure('My Title');
+        $person->setDeathDaySure('My Title');
+        $person->setDeathMonthSure('My Title');
+        $person->setDeathYearSure('My Title');
+        $person->setPortrait('My Title');
+        $person->setBio('My Title');
+        $person->setUnions('My Title');
+        $person->setParentUnion('My Title');
+        $person->setTree('My Title');
 
-        $this->manager->persist($fixture);
+        $this->manager->persist($person);
         $this->manager->flush();
 
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $fixture->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $person->getId()));
 
         self::assertResponseStatusCodeSame(200);
         self::assertPageTitleContains('Person');
@@ -170,27 +170,27 @@ class PersonControllerTest extends WebTestCase
     public function testRemove(): void
     {
         $this->markTestIncomplete();
-        $fixture = new Person();
-        $fixture->setFirstname('Value');
-        $fixture->setLastname('Value');
-        $fixture->setBirth('Value');
-        $fixture->setDeath('Value');
-        $fixture->setBirthDaySure('Value');
-        $fixture->setBirthMonthSure('Value');
-        $fixture->setBirthYearSure('Value');
-        $fixture->setDeathDaySure('Value');
-        $fixture->setDeathMonthSure('Value');
-        $fixture->setDeathYearSure('Value');
-        $fixture->setPortrait('Value');
-        $fixture->setBio('Value');
-        $fixture->setUnions('Value');
-        $fixture->setParentUnion('Value');
-        $fixture->setTree('Value');
+        $person = new Person();
+        $person->setFirstname('Value');
+        $person->setLastname('Value');
+        $person->setBirth('Value');
+        $person->setDeath('Value');
+        $person->setBirthDaySure('Value');
+        $person->setBirthMonthSure('Value');
+        $person->setBirthYearSure('Value');
+        $person->setDeathDaySure('Value');
+        $person->setDeathMonthSure('Value');
+        $person->setDeathYearSure('Value');
+        $person->setPortrait('Value');
+        $person->setBio('Value');
+        $person->setUnions('Value');
+        $person->setParentUnion('Value');
+        $person->setTree('Value');
 
-        $this->manager->remove($fixture);
+        $this->manager->remove($person);
         $this->manager->flush();
 
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $fixture->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $person->getId()));
         $this->client->submitForm('Delete');
 
         self::assertResponseRedirects('/person/');

--- a/tests/Controller/PersonControllerTest.php
+++ b/tests/Controller/PersonControllerTest.php
@@ -30,7 +30,7 @@ class PersonControllerTest extends WebTestCase
 
     public function testIndex(): void
     {
-        $crawler = $this->client->request('GET', $this->path);
+        $this->client->request('GET', $this->path);
 
         self::assertResponseStatusCodeSame(200);
         self::assertPageTitleContains('Person index');

--- a/tests/Controller/PersonControllerTest.php
+++ b/tests/Controller/PersonControllerTest.php
@@ -11,8 +11,11 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 class PersonControllerTest extends WebTestCase
 {
     private KernelBrowser $client;
+
     private EntityManagerInterface $manager;
+
     private EntityRepository $repository;
+
     private string $path = '/person/';
 
     protected function setUp(): void

--- a/tests/Controller/PersonControllerTest.php
+++ b/tests/Controller/PersonControllerTest.php
@@ -24,8 +24,8 @@ class PersonControllerTest extends WebTestCase
         $this->entityManager = static::getContainer()->get('doctrine')->getManager();
         $this->entityRepository = $this->entityManager->getRepository(Person::class);
 
-        foreach ($this->entityRepository->findAll() as $object) {
-            $this->entityManager->remove($object);
+        foreach ($this->entityRepository->findAll() as $person) {
+            $this->entityManager->remove($person);
         }
 
         $this->entityManager->flush();

--- a/tests/Controller/PersonControllerTest.php
+++ b/tests/Controller/PersonControllerTest.php
@@ -10,30 +10,30 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class PersonControllerTest extends WebTestCase
 {
-    private KernelBrowser $client;
+    private KernelBrowser $kernelBrowser;
 
-    private EntityManagerInterface $manager;
+    private EntityManagerInterface $entityManager;
 
-    private EntityRepository $repository;
+    private EntityRepository $entityRepository;
 
     private string $path = '/person/';
 
     protected function setUp(): void
     {
-        $this->client = static::createClient();
-        $this->manager = static::getContainer()->get('doctrine')->getManager();
-        $this->repository = $this->manager->getRepository(Person::class);
+        $this->kernelBrowser = static::createClient();
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+        $this->entityRepository = $this->entityManager->getRepository(Person::class);
 
-        foreach ($this->repository->findAll() as $object) {
-            $this->manager->remove($object);
+        foreach ($this->entityRepository->findAll() as $object) {
+            $this->entityManager->remove($object);
         }
 
-        $this->manager->flush();
+        $this->entityManager->flush();
     }
 
     public function testIndex(): void
     {
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->path);
+        $this->kernelBrowser->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->path);
 
         self::assertResponseStatusCodeSame(200);
         self::assertPageTitleContains('Person index');
@@ -45,11 +45,11 @@ class PersonControllerTest extends WebTestCase
     public function testNew(): void
     {
         $this->markTestIncomplete();
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%snew', $this->path));
+        $this->kernelBrowser->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%snew', $this->path));
 
         self::assertResponseStatusCodeSame(200);
 
-        $this->client->submitForm('Save', [
+        $this->kernelBrowser->submitForm('Save', [
             'person[firstname]' => 'Testing',
             'person[lastname]' => 'Testing',
             'person[birth]' => 'Testing',
@@ -92,10 +92,10 @@ class PersonControllerTest extends WebTestCase
         $person->setParentUnion('My Title');
         $person->setTree('My Title');
 
-        $this->manager->persist($person);
-        $this->manager->flush();
+        $this->entityManager->persist($person);
+        $this->entityManager->flush();
 
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $person->getId()));
+        $this->kernelBrowser->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $person->getId()));
 
         self::assertResponseStatusCodeSame(200);
         self::assertPageTitleContains('Person');
@@ -123,12 +123,12 @@ class PersonControllerTest extends WebTestCase
         $fixture->setParentUnion('Value');
         $fixture->setTree('Value');
 
-        $this->manager->persist($fixture);
-        $this->manager->flush();
+        $this->entityManager->persist($fixture);
+        $this->entityManager->flush();
 
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s/edit', $this->path, $fixture->getId()));
+        $this->kernelBrowser->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s/edit', $this->path, $fixture->getId()));
 
-        $this->client->submitForm('Update', [
+        $this->kernelBrowser->submitForm('Update', [
             'person[firstname]' => 'Something New',
             'person[lastname]' => 'Something New',
             'person[birth]' => 'Something New',
@@ -148,7 +148,7 @@ class PersonControllerTest extends WebTestCase
 
         self::assertResponseRedirects('/person/');
 
-        $fixture = $this->repository->findAll();
+        $fixture = $this->entityRepository->findAll();
 
         self::assertSame('Something New', $fixture[0]->getFirstname());
         self::assertSame('Something New', $fixture[0]->getLastname());
@@ -187,13 +187,13 @@ class PersonControllerTest extends WebTestCase
         $person->setParentUnion('Value');
         $person->setTree('Value');
 
-        $this->manager->remove($person);
-        $this->manager->flush();
+        $this->entityManager->remove($person);
+        $this->entityManager->flush();
 
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $person->getId()));
-        $this->client->submitForm('Delete');
+        $this->kernelBrowser->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $person->getId()));
+        $this->kernelBrowser->submitForm('Delete');
 
         self::assertResponseRedirects('/person/');
-        self::assertSame(0, $this->repository->count([]));
+        self::assertSame(0, $this->entityRepository->count([]));
     }
 }

--- a/tests/Controller/PersonControllerTest.php
+++ b/tests/Controller/PersonControllerTest.php
@@ -30,7 +30,7 @@ class PersonControllerTest extends WebTestCase
 
     public function testIndex(): void
     {
-        $this->client->request('GET', $this->path);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->path);
 
         self::assertResponseStatusCodeSame(200);
         self::assertPageTitleContains('Person index');
@@ -42,7 +42,7 @@ class PersonControllerTest extends WebTestCase
     public function testNew(): void
     {
         $this->markTestIncomplete();
-        $this->client->request('GET', sprintf('%snew', $this->path));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%snew', $this->path));
 
         self::assertResponseStatusCodeSame(200);
 
@@ -92,7 +92,7 @@ class PersonControllerTest extends WebTestCase
         $this->manager->persist($fixture);
         $this->manager->flush();
 
-        $this->client->request('GET', sprintf('%s%s', $this->path, $fixture->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $fixture->getId()));
 
         self::assertResponseStatusCodeSame(200);
         self::assertPageTitleContains('Person');
@@ -123,7 +123,7 @@ class PersonControllerTest extends WebTestCase
         $this->manager->persist($fixture);
         $this->manager->flush();
 
-        $this->client->request('GET', sprintf('%s%s/edit', $this->path, $fixture->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s/edit', $this->path, $fixture->getId()));
 
         $this->client->submitForm('Update', [
             'person[firstname]' => 'Something New',
@@ -187,7 +187,7 @@ class PersonControllerTest extends WebTestCase
         $this->manager->remove($fixture);
         $this->manager->flush();
 
-        $this->client->request('GET', sprintf('%s%s', $this->path, $fixture->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $fixture->getId()));
         $this->client->submitForm('Delete');
 
         self::assertResponseRedirects('/person/');

--- a/tests/Controller/TreeControllerTest.php
+++ b/tests/Controller/TreeControllerTest.php
@@ -64,7 +64,7 @@ class TreeControllerTest extends WebTestCase
         $this->markTestIncomplete();
         $tree = new Tree();
         $tree->setCreatedAt('My Title');
-        $tree->setOwner('My Title');
+        $tree->setUser('My Title');
 
         $this->entityManager->persist($tree);
         $this->entityManager->flush();
@@ -82,7 +82,7 @@ class TreeControllerTest extends WebTestCase
         $this->markTestIncomplete();
         $fixture = new Tree();
         $fixture->setCreatedAt('Value');
-        $fixture->setOwner('Value');
+        $fixture->setUser('Value');
 
         $this->entityManager->persist($fixture);
         $this->entityManager->flush();
@@ -107,7 +107,7 @@ class TreeControllerTest extends WebTestCase
         $this->markTestIncomplete();
         $tree = new Tree();
         $tree->setCreatedAt('Value');
-        $tree->setOwner('Value');
+        $tree->setUser('Value');
 
         $this->entityManager->remove($tree);
         $this->entityManager->flush();

--- a/tests/Controller/TreeControllerTest.php
+++ b/tests/Controller/TreeControllerTest.php
@@ -24,8 +24,8 @@ class TreeControllerTest extends WebTestCase
         $this->entityManager = static::getContainer()->get('doctrine')->getManager();
         $this->entityRepository = $this->entityManager->getRepository(Tree::class);
 
-        foreach ($this->entityRepository->findAll() as $object) {
-            $this->entityManager->remove($object);
+        foreach ($this->entityRepository->findAll() as $tree) {
+            $this->entityManager->remove($tree);
         }
 
         $this->entityManager->flush();

--- a/tests/Controller/TreeControllerTest.php
+++ b/tests/Controller/TreeControllerTest.php
@@ -62,14 +62,14 @@ class TreeControllerTest extends WebTestCase
     public function testShow(): void
     {
         $this->markTestIncomplete();
-        $fixture = new Tree();
-        $fixture->setCreatedAt('My Title');
-        $fixture->setOwner('My Title');
+        $tree = new Tree();
+        $tree->setCreatedAt('My Title');
+        $tree->setOwner('My Title');
 
-        $this->manager->persist($fixture);
+        $this->manager->persist($tree);
         $this->manager->flush();
 
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $fixture->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $tree->getId()));
 
         self::assertResponseStatusCodeSame(200);
         self::assertPageTitleContains('Tree');
@@ -105,14 +105,14 @@ class TreeControllerTest extends WebTestCase
     public function testRemove(): void
     {
         $this->markTestIncomplete();
-        $fixture = new Tree();
-        $fixture->setCreatedAt('Value');
-        $fixture->setOwner('Value');
+        $tree = new Tree();
+        $tree->setCreatedAt('Value');
+        $tree->setOwner('Value');
 
-        $this->manager->remove($fixture);
+        $this->manager->remove($tree);
         $this->manager->flush();
 
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $fixture->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $tree->getId()));
         $this->client->submitForm('Delete');
 
         self::assertResponseRedirects('/tree/');

--- a/tests/Controller/TreeControllerTest.php
+++ b/tests/Controller/TreeControllerTest.php
@@ -30,7 +30,7 @@ class TreeControllerTest extends WebTestCase
 
     public function testIndex(): void
     {
-        $this->client->request('GET', $this->path);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->path);
 
         self::assertResponseStatusCodeSame(200);
         self::assertPageTitleContains('Tree index');
@@ -42,7 +42,7 @@ class TreeControllerTest extends WebTestCase
     public function testNew(): void
     {
         $this->markTestIncomplete();
-        $this->client->request('GET', sprintf('%snew', $this->path));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%snew', $this->path));
 
         self::assertResponseStatusCodeSame(200);
 
@@ -66,7 +66,7 @@ class TreeControllerTest extends WebTestCase
         $this->manager->persist($fixture);
         $this->manager->flush();
 
-        $this->client->request('GET', sprintf('%s%s', $this->path, $fixture->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $fixture->getId()));
 
         self::assertResponseStatusCodeSame(200);
         self::assertPageTitleContains('Tree');
@@ -84,7 +84,7 @@ class TreeControllerTest extends WebTestCase
         $this->manager->persist($fixture);
         $this->manager->flush();
 
-        $this->client->request('GET', sprintf('%s%s/edit', $this->path, $fixture->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s/edit', $this->path, $fixture->getId()));
 
         $this->client->submitForm('Update', [
             'tree[createdAt]' => 'Something New',
@@ -109,7 +109,7 @@ class TreeControllerTest extends WebTestCase
         $this->manager->remove($fixture);
         $this->manager->flush();
 
-        $this->client->request('GET', sprintf('%s%s', $this->path, $fixture->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $fixture->getId()));
         $this->client->submitForm('Delete');
 
         self::assertResponseRedirects('/tree/');

--- a/tests/Controller/TreeControllerTest.php
+++ b/tests/Controller/TreeControllerTest.php
@@ -10,30 +10,30 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class TreeControllerTest extends WebTestCase
 {
-    private KernelBrowser $client;
+    private KernelBrowser $kernelBrowser;
 
-    private EntityManagerInterface $manager;
+    private EntityManagerInterface $entityManager;
 
-    private EntityRepository $repository;
+    private EntityRepository $entityRepository;
 
     private string $path = '/tree/';
 
     protected function setUp(): void
     {
-        $this->client = static::createClient();
-        $this->manager = static::getContainer()->get('doctrine')->getManager();
-        $this->repository = $this->manager->getRepository(Tree::class);
+        $this->kernelBrowser = static::createClient();
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+        $this->entityRepository = $this->entityManager->getRepository(Tree::class);
 
-        foreach ($this->repository->findAll() as $object) {
-            $this->manager->remove($object);
+        foreach ($this->entityRepository->findAll() as $object) {
+            $this->entityManager->remove($object);
         }
 
-        $this->manager->flush();
+        $this->entityManager->flush();
     }
 
     public function testIndex(): void
     {
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->path);
+        $this->kernelBrowser->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->path);
 
         self::assertResponseStatusCodeSame(200);
         self::assertPageTitleContains('Tree index');
@@ -45,11 +45,11 @@ class TreeControllerTest extends WebTestCase
     public function testNew(): void
     {
         $this->markTestIncomplete();
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%snew', $this->path));
+        $this->kernelBrowser->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%snew', $this->path));
 
         self::assertResponseStatusCodeSame(200);
 
-        $this->client->submitForm('Save', [
+        $this->kernelBrowser->submitForm('Save', [
             'tree[createdAt]' => 'Testing',
             'tree[owner]' => 'Testing',
         ]);
@@ -66,10 +66,10 @@ class TreeControllerTest extends WebTestCase
         $tree->setCreatedAt('My Title');
         $tree->setOwner('My Title');
 
-        $this->manager->persist($tree);
-        $this->manager->flush();
+        $this->entityManager->persist($tree);
+        $this->entityManager->flush();
 
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $tree->getId()));
+        $this->kernelBrowser->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $tree->getId()));
 
         self::assertResponseStatusCodeSame(200);
         self::assertPageTitleContains('Tree');
@@ -84,19 +84,19 @@ class TreeControllerTest extends WebTestCase
         $fixture->setCreatedAt('Value');
         $fixture->setOwner('Value');
 
-        $this->manager->persist($fixture);
-        $this->manager->flush();
+        $this->entityManager->persist($fixture);
+        $this->entityManager->flush();
 
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s/edit', $this->path, $fixture->getId()));
+        $this->kernelBrowser->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s/edit', $this->path, $fixture->getId()));
 
-        $this->client->submitForm('Update', [
+        $this->kernelBrowser->submitForm('Update', [
             'tree[createdAt]' => 'Something New',
             'tree[owner]' => 'Something New',
         ]);
 
         self::assertResponseRedirects('/tree/');
 
-        $fixture = $this->repository->findAll();
+        $fixture = $this->entityRepository->findAll();
 
         self::assertSame('Something New', $fixture[0]->getCreatedAt());
         self::assertSame('Something New', $fixture[0]->getOwner());
@@ -109,13 +109,13 @@ class TreeControllerTest extends WebTestCase
         $tree->setCreatedAt('Value');
         $tree->setOwner('Value');
 
-        $this->manager->remove($tree);
-        $this->manager->flush();
+        $this->entityManager->remove($tree);
+        $this->entityManager->flush();
 
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $tree->getId()));
-        $this->client->submitForm('Delete');
+        $this->kernelBrowser->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('%s%s', $this->path, $tree->getId()));
+        $this->kernelBrowser->submitForm('Delete');
 
         self::assertResponseRedirects('/tree/');
-        self::assertSame(0, $this->repository->count([]));
+        self::assertSame(0, $this->entityRepository->count([]));
     }
 }

--- a/tests/Controller/TreeControllerTest.php
+++ b/tests/Controller/TreeControllerTest.php
@@ -30,7 +30,7 @@ class TreeControllerTest extends WebTestCase
 
     public function testIndex(): void
     {
-        $crawler = $this->client->request('GET', $this->path);
+        $this->client->request('GET', $this->path);
 
         self::assertResponseStatusCodeSame(200);
         self::assertPageTitleContains('Tree index');

--- a/tests/Controller/TreeControllerTest.php
+++ b/tests/Controller/TreeControllerTest.php
@@ -11,8 +11,11 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 class TreeControllerTest extends WebTestCase
 {
     private KernelBrowser $client;
+
     private EntityManagerInterface $manager;
+
     private EntityRepository $repository;
+
     private string $path = '/tree/';
 
     protected function setUp(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add and configure PHPStan, Rector, and PHP-CS-Fixer for the Symfony application with Composer scripts and repo-level config
- progressively enable PHP 8.4, Symfony, Doctrine, and additional Rector prepared sets, committing each applied rule separately for traceability
- apply the resulting automated refactors and formatting updates across controllers, entities, forms, repositories, services, fixtures, and tests, including a follow-up fix for the `Tree` owner accessor rename

## Testing
- docker compose exec apache composer rector
- docker compose exec apache composer analyse
- docker compose exec apache composer cs:check