### PR TITLE
Fix person profile edit navigation

### DIFF
--- a/templates/person/_form.html.twig
+++ b/templates/person/_form.html.twig
@@ -62,7 +62,11 @@
 
     <div class="row g-1 justify-content-end">
         <div class="col-auto">
-            <a href="{{ path('app_tree_show', { id: tree.id }) }}" class="btn btn-secondary">Annuler</a>
+            {% set cancel_path = person.id
+                ? path('app_person_show', { id: person.id })
+                : path('app_tree_show', { id: tree.id })
+            %}
+            <a href="{{ cancel_path }}" class="btn btn-secondary">Annuler</a>
         </div>
         <div class="col-auto">
             <button class="btn btn-primary">{{ button_label|default('Ajouter') }}</button>

--- a/templates/person/base.html.twig
+++ b/templates/person/base.html.twig
@@ -55,10 +55,19 @@
                         </ul>
                     </div>
 
-                    <a href="{{ path('app_person_tree', { id: person.id }) }}" class="btn btn-secondary w-100">
-                        <i class="fa-solid fa-tree"></i>
-                        {{ 'action.see_tree'|trans }}
-                    </a>
+                    <div class="d-grid gap-2">
+                        {% if is_granted('edit', person) %}
+                            <a href="{{ path('app_person_edit', { id: person.id }) }}" class="btn btn-primary w-100">
+                                <i class="fa-solid fa-edit"></i>
+                                {{ 'action.edit'|trans }}
+                            </a>
+                        {% endif %}
+
+                        <a href="{{ path('app_person_tree', { id: person.id }) }}" class="btn btn-secondary w-100">
+                            <i class="fa-solid fa-tree"></i>
+                            {{ 'action.see_tree'|trans }}
+                        </a>
+                    </div>
                 </div>
                 
                 <div class="col-12 col-md-8 col-lg-9">
@@ -66,9 +75,9 @@
                         <ul class="nav nav-underline" style="gap: 0 var(--bs-nav-underline-gap);">
                             <li class="nav-item">
                                 <a 
-                                    class="nav-link{{ route_name == 'app_person_show' ? ' active':'' }}"
+                                    class="nav-link{{ route_name in ['app_person_show', 'app_person_edit'] ? ' active':'' }}"
                                     href="{{ path('app_person_show', {id: person.id}) }}"
-                                    {% if route_name == 'app_person_show' %}aria-current="page"{% endif %}
+                                    {% if route_name in ['app_person_show', 'app_person_edit'] %}aria-current="page"{% endif %}
                                 >
                                     <i class="fa-solid fa-user-circle"></i>
                                     {{ 'label.profile'|trans }}
@@ -87,16 +96,6 @@
                                 >
                                     <i class="fa-solid fa-family"></i>
                                     {{ 'label.unions'|trans }}
-                                </a>
-                            </li>
-                            <li class="nav-item">
-                                <a
-                                    class="nav-link{{ route_name == 'app_person_edit' ? ' active':'' }}"
-                                    href="{{ path('app_person_edit', {id: person.id}) }}"
-                                    {% if route_name == 'app_person_edit' %}aria-current="page"{% endif %}
-                                >
-                                    <i class="fa-solid fa-edit"></i>
-                                    {{ 'action.edit'|trans }}
                                 </a>
                             </li>
                             <li class="nav-item">


### PR DESCRIPTION
## Summary
- move the person edit action from the top tab navigation into the left profile summary sheet
- keep the Profile tab active while editing a person so the current section stays clear
- send the edit form cancel action back to the profile page while preserving the add-member cancel path

## Testing
- not run (Twig/UI change)

Fixes #127