### PR TITLE
Fix deprecated Doctrine prod parameters

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -28,8 +28,6 @@ when@test:
 when@prod:
     doctrine:
         orm:
-            auto_generate_proxy_classes: false
-            proxy_dir: '%kernel.build_dir%/doctrine/orm/Proxies'
             query_cache_driver:
                 type: pool
                 pool: doctrine.system_cache_pool


### PR DESCRIPTION
## Summary
- remove deprecated Doctrine ORM prod parameters from `config/packages/doctrine.yaml`
- keep the production cache pool configuration intact
- avoid prod configuration warnings or failures on current Symfony and Doctrine versions

## Testing
- not run (configuration-only change)