### PR TITLE
Fix deploy PHP 8.4 compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.4
 
       - name: Setup env
         run: |
@@ -33,7 +33,7 @@ jobs:
         uses: ramsey/composer-install@v2
         with:
           dependency-versions: locked
-          composer-options: "--ignore-platform-reqs --optimize-autoloader --no-dev"
+          composer-options: "--optimize-autoloader --no-dev"
 
       - name: Import assets
         run: |

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "doctrine/doctrine-bundle": "^3.2",


### PR DESCRIPTION
## Summary
- run the deploy workflow on PHP 8.4 to match the locked Symfony dependency set
- stop using `--ignore-platform-reqs` during production installs so Composer fails fast on runtime mismatches
- raise the declared project PHP requirement to 8.4 so repository metadata matches the actual supported runtime

## Testing
- not run (CI and Composer configuration change)