### PR TITLE
feat: add favorite family members to tree view

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -20,7 +20,6 @@ return RectorConfig::configure()
         instanceOf: true,
         naming: true,
         privatization: true,
-        strictBooleans: true,
         symfonyCodeQuality: true,
         typeDeclarationDocblocks: true,
         typeDeclarations: true,

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -3,21 +3,24 @@
 namespace App\Controller;
 
 use App\Entity\Person;
+use App\Entity\User;
 use App\Form\PersonType;
 use App\Form\TreeOptionsType;
+use App\Service\FavoriteMemberManager;
 use App\Service\ImageManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class PersonController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager, private readonly ImageManager $imageManager,
+        private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager, private readonly ImageManager $imageManager, private readonly FavoriteMemberManager $favoriteMemberManager,
     ) {
     }
 
@@ -123,5 +126,31 @@ class PersonController extends AbstractController
             'form' => $form->createView(),
             'tree_view' => true,
         ]);
+    }
+
+    #[Route('/person/{id}/favorite', name: 'app_person_favorite', methods: [Request::METHOD_GET])]
+    public function favorite(Person $person, #[CurrentUser()] User $user): Response
+    {
+        $this->favoriteMemberManager->favorite($person, $user);
+
+        $this->addFlash(
+            'success',
+            $this->translator->trans('person.favorite.added', ['name' => $person->getFullName()]),
+        );
+
+        return $this->redirectToRoute('app_tree_show', ['id' => $person->getTree()->getId()]);
+    }
+
+    #[Route('/person/{id}/unfavorite', name: 'app_person_unfavorite', methods: [Request::METHOD_GET])]
+    public function unfavorite(Person $person, #[CurrentUser()] User $user): Response
+    {
+        $this->favoriteMemberManager->unfavorite($person, $user);
+
+        $this->addFlash(
+            'success',
+            $this->translator->trans('person.favorite.removed', ['name' => $person->getFullName()]),
+        );
+
+        return $this->redirectToRoute('app_tree_show', ['id' => $person->getTree()->getId()]);
     }
 }

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -10,6 +10,7 @@ use App\Form\PersonType;
 use App\Form\TreeType;
 use App\Repository\PersonRepository;
 use App\Service\ImageManager;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -62,7 +63,8 @@ class TreeController extends AbstractController
         $form = $this->createForm(MembersSearchType::class);
         $form->handleRequest($request);
 
-        $members = $tree->getMembers();
+        $members = $this->personRepository->findByTreeWithFavorites($tree);
+        $members = new ArrayCollection($members);
 
         // Filtre de recherche
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Form\MembersSearchType;
 use App\Form\PersonType;
 use App\Form\TreeType;
+use App\Repository\PersonRepository;
 use App\Service\ImageManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -21,7 +22,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class TreeController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager, private readonly ImageManager $imageManager,
+        private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager, private readonly ImageManager $imageManager, private readonly PersonRepository $personRepository,
     ) {
     }
 
@@ -56,7 +57,7 @@ class TreeController extends AbstractController
     }
 
     #[Route('/project/{id}', name: 'app_tree_show', methods: ['GET'])]
-    public function show(Tree $tree, Request $request): Response
+    public function show(Tree $tree, Request $request, #[CurrentUser()] User $user): Response
     {
         $form = $this->createForm(MembersSearchType::class);
         $form->handleRequest($request);
@@ -92,6 +93,7 @@ class TreeController extends AbstractController
             'form' => $form->createView(),
             'grouped_members' => $groupedMembers,
             'members_count' => $members->count(),
+            'favorites' => $this->personRepository->findFavoritesInTree($tree, $user),
         ]);
     }
 

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -23,7 +23,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class TreeController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager, private readonly ImageManager $imageManager, private readonly PersonRepository $personRepository,
+        private readonly TranslatorInterface $translator,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly ImageManager $imageManager,
+        private readonly PersonRepository $personRepository,
     ) {
     }
 
@@ -80,7 +83,12 @@ class TreeController extends AbstractController
 
         // Tri par ordre alphabétique
         $orderedMembers = $members->toArray();
-        usort($orderedMembers, fn ($a, $b): int => strcmp(trim($a->getFullName()), trim($b->getFullName())));
+        usort(
+            $orderedMembers,
+            fn ($a, $b): int => strcmp(
+                trim($a->getFullName()),
+                trim($b->getFullName())
+            ));
 
         // Groupement par première lettre
         $groupedMembers = array_reduce($orderedMembers, function (array $groupedMembers, Person $person): array {

--- a/src/Entity/FavoriteMember.php
+++ b/src/Entity/FavoriteMember.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\FavoriteMemberRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: FavoriteMemberRepository::class)]
+class FavoriteMember
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(inversedBy: 'favorites')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $user = null;
+
+    #[ORM\ManyToOne(inversedBy: 'favorites')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Person $person = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): static
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getPerson(): ?Person
+    {
+        return $this->person;
+    }
+
+    public function setPerson(?Person $person): static
+    {
+        $this->person = $person;
+
+        return $this;
+    }
+}

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -94,6 +94,9 @@ class Person implements \Stringable
     #[ORM\OneToMany(targetEntity: Source::class, mappedBy: 'person', orphanRemoval: true)]
     private Collection $sources;
 
+    #[ORM\OneToMany(targetEntity: FavoriteMember::class, mappedBy: 'person', orphanRemoval: true)]
+    private Collection $favorites;
+
     public function __construct()
     {
         $this->unions = new ArrayCollection();
@@ -434,5 +437,40 @@ class Person implements \Stringable
         }
 
         return $this;
+    }
+
+    /**
+     * @return Collection<int, FavoriteMember>
+     */
+    public function getFavorites(): Collection
+    {
+        return $this->favorites;
+    }
+
+    public function addFavorite(FavoriteMember $favoriteMember): static
+    {
+        if (!$this->favorites->contains($favoriteMember)) {
+            $this->favorites->add($favoriteMember);
+            $favoriteMember->setPerson($this);
+        }
+
+        return $this;
+    }
+
+    public function removeFavorite(FavoriteMember $favoriteMember): static
+    {
+        // set the owning side to null (unless already changed)
+        if ($this->favorites->removeElement($favoriteMember) && $favoriteMember->getPerson() === $this) {
+            $favoriteMember->setPerson(null);
+        }
+
+        return $this;
+    }
+
+    public function isFavoriteOf(User $user): bool
+    {
+        return $this->favorites->findFirst(
+            fn (int $index, FavoriteMember $favoriteMember): bool => $favoriteMember->getUser()->getId() === $user->getId()
+        ) instanceof FavoriteMember;
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -44,9 +44,16 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\OneToMany(targetEntity: Tree::class, mappedBy: 'user', orphanRemoval: true)]
     private Collection $trees;
 
+    /**
+     * @var Collection<int, FavoriteMember>
+     */
+    #[ORM\OneToMany(targetEntity: FavoriteMember::class, mappedBy: 'user', orphanRemoval: true)]
+    private Collection $favorites;
+
     public function __construct()
     {
         $this->trees = new ArrayCollection();
+        $this->favorites = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -178,6 +185,34 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         // set the owning side to null (unless already changed)
         if ($this->trees->removeElement($tree) && $tree->getUser() === $this) {
             $tree->setUser(null);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, FavoriteMember>
+     */
+    public function getFavorites(): Collection
+    {
+        return $this->favorites;
+    }
+
+    public function addFavorite(FavoriteMember $favoriteMember): static
+    {
+        if (!$this->favorites->contains($favoriteMember)) {
+            $this->favorites->add($favoriteMember);
+            $favoriteMember->setUser($this);
+        }
+
+        return $this;
+    }
+
+    public function removeFavorite(FavoriteMember $favoriteMember): static
+    {
+        // set the owning side to null (unless already changed)
+        if ($this->favorites->removeElement($favoriteMember) && $favoriteMember->getUser() === $this) {
+            $favoriteMember->setUser(null);
         }
 
         return $this;

--- a/src/Repository/FavoriteMemberRepository.php
+++ b/src/Repository/FavoriteMemberRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\FavoriteMember;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<FavoriteMember>
+ */
+class FavoriteMemberRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, FavoriteMember::class);
+    }
+}

--- a/src/Repository/PersonRepository.php
+++ b/src/Repository/PersonRepository.php
@@ -70,4 +70,21 @@ class PersonRepository extends ServiceEntityRepository
 
         return array_map(static fn (FavoriteMember $favoriteMember): ?Person => $favoriteMember->getPerson(), $query->getResult());
     }
+
+    /**
+     * @return array<int, Person>
+     */
+    public function findByTreeWithFavorites(Tree $tree): array
+    {
+        $queryBuilder = $this->createQueryBuilder('p');
+        $query = $queryBuilder
+            ->select('p, f')
+            ->leftJoin('p.favorites', 'f')
+            ->where('p.tree = :tree')
+            ->setParameter('tree', $tree)
+            ->getQuery()
+        ;
+
+        return $query->getResult();
+    }
 }

--- a/src/Repository/PersonRepository.php
+++ b/src/Repository/PersonRepository.php
@@ -2,8 +2,10 @@
 
 namespace App\Repository;
 
+use App\Entity\FavoriteMember;
 use App\Entity\Person;
 use App\Entity\Tree;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -49,28 +51,23 @@ class PersonRepository extends ServiceEntityRepository
         ;
     }
 
-    //    /**
-    //     * @return Person[] Returns an array of Person objects
-    //     */
-    //    public function findByExampleField($value): array
-    //    {
-    //        return $this->createQueryBuilder('p')
-    //            ->andWhere('p.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->orderBy('p.id', 'ASC')
-    //            ->setMaxResults(10)
-    //            ->getQuery()
-    //            ->getResult()
-    //        ;
-    //    }
+    /**
+     * @return array<int, Person>
+     */
+    public function findFavoritesInTree(Tree $tree, User $user): array
+    {
+        $queryBuilder = $this->getEntityManager()->createQueryBuilder();
+        $query = $queryBuilder
+            ->select('f')
+            ->from(FavoriteMember::class, 'f')
+            ->leftJoin('f.person', 'p')
+            ->where('f.user = :user')
+            ->andWhere('p.tree = :tree')
+            ->setParameter('user', $user)
+            ->setParameter('tree', $tree)
+            ->getQuery()
+        ;
 
-    //    public function findOneBySomeField($value): ?Person
-    //    {
-    //        return $this->createQueryBuilder('p')
-    //            ->andWhere('p.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->getQuery()
-    //            ->getOneOrNullResult()
-    //        ;
-    //    }
+        return array_map(static fn (FavoriteMember $favoriteMember): ?Person => $favoriteMember->getPerson(), $query->getResult());
+    }
 }

--- a/src/Service/FavoriteMemberManager.php
+++ b/src/Service/FavoriteMemberManager.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\FavoriteMember;
+use App\Entity\Person;
+use App\Entity\User;
+use App\Repository\FavoriteMemberRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+class FavoriteMemberManager
+{
+    public function __construct(
+        private readonly FavoriteMemberRepository $favoriteMemberRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    protected function isFavorite(Person $person, User $user): bool
+    {
+        $favoriteMember = $this->favoriteMemberRepository->findOneBy([
+            'user' => $user,
+            'person' => $person,
+        ]);
+
+        return $favoriteMember instanceof FavoriteMember;
+    }
+
+    public function favorite(Person $person, User $user): void
+    {
+        $person->getTree();
+
+        if ($this->isFavorite($person, $user)) {
+            return;
+        }
+
+        $favoriteMember = new FavoriteMember();
+        $favoriteMember
+            ->setPerson($person)
+            ->setUser($user)
+        ;
+
+        $this->entityManager->persist($favoriteMember);
+        $this->entityManager->flush();
+    }
+
+    public function unfavorite(Person $person, User $user): void
+    {
+        $favoriteMember = $this->favoriteMemberRepository->findOneBy([
+            'user' => $user,
+            'person' => $person,
+        ]);
+
+        if (!$favoriteMember instanceof FavoriteMember) {
+            return;
+        }
+
+        $this->entityManager->remove($favoriteMember);
+        $this->entityManager->flush();
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -12,7 +12,7 @@
         {% block javascripts %}
             {% block importmap %}{{ importmap('app') }}{% endblock %}
         {% endblock %}
-        <script src="https://kit.fontawesome.com/431529382e.js" crossorigin="anonymous"></script>
+        <script src="https://kit.fontawesome.com/e97ca962c1.js" crossorigin="anonymous"></script>
     </head>
     <body class="h-100 d-flex flex-column" style="background-color: var(--bs-tertiary-bg);">
         {% include "_includes/main/navbar.html.twig" %}

--- a/templates/tree/_member_list_item.html.twig
+++ b/templates/tree/_member_list_item.html.twig
@@ -52,6 +52,19 @@
 
             {% if is_granted('edit', member) %}
                 <li>
+                    {% if member.isFavoriteOf(app.user) %}
+                        <a href="{{ path('app_person_unfavorite', { id: member.id }) }}" class="dropdown-item">
+                            <i class="fa-kit fa-solid-star-slash"></i>
+                            {{ 'action.remove_favorite'|trans }}
+                        </a>
+                    {% else %}
+                        <a href="{{ path('app_person_favorite', { id: member.id }) }}" class="dropdown-item">
+                            <i class="fa-solid fa-star"></i>
+                            {{ 'action.add_favorite'|trans }}
+                        </a>
+                    {% endif %}
+                </li>
+                <li>
                     <a 
                         href="{{ path('app_person_edit', { id: member.id }) }}" 
                         class="dropdown-item"

--- a/templates/tree/show.html.twig
+++ b/templates/tree/show.html.twig
@@ -22,6 +22,17 @@
                         {{ 'action.new_member'|trans }}
                     </a>
                 </div>
+
+                {% if favorites|length %}
+                    <div class="h6 mt-3">{{ 'label.favorites'|trans }}</div>
+                    <ul class="list-group">
+                        {% for member in favorites %}
+                            <li class="list-group-item">
+                                {{ include("tree/_member_list_item.html.twig", { member }) }}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
             </div>
 
             <div class="col">

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -70,6 +70,8 @@ action:
     see_tree: See tree
     show: Show
     update: Update
+    add_favorite: Add to favorites
+    remove_favorite: Remove from favorites
 nav:
     profile: Profile
     my_projects: My projects
@@ -94,6 +96,7 @@ label:
     profile: Profile
     direct_proof: Direct proof
     life_line: Life line
+    favorites: Favorites
 title:
     add_child: Add a child
     add_member: Add a member
@@ -138,6 +141,9 @@ person:
     delete:
         success: '**{name}** has been successfully deleted.'
         error: '**{name}** has not been deleted.'
+    favorite:
+        added: '**{name}** has been successfully added to favorites.'
+        removed: '**{name}** has been successfully removed from favorites.'
 tree:
     new:
         success: 'The tree **{name}** has been successfully created.'

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -70,6 +70,8 @@ action:
     see_tree: Voir l'arbre
     show: Afficher
     update: Mettre à jour
+    add_favorite: 'Ajouter aux favoris'
+    remove_favorite: 'Supprimer des favoris'
 nav:
     profile: Profil
     my_projects: Mes projets
@@ -94,6 +96,7 @@ label:
     profile: Profil
     direct_proof: Preuve directe
     life_line: Ligne de vie
+    favorites: Favoris
 title:
     add_child: Ajouter un enfant
     add_member: Ajouter un membre
@@ -139,6 +142,9 @@ person:
     delete:
         success: '**{name}** a bien été supprimé.'
         error: "**{name}** n'a pas été supprimé."
+    favorite:
+        added: "**{name}** a bien été ajouté aux favoris."
+        removed: "**{name}** a bien été enlevé des favoris."
 tree:
     new:
         success: "L'arbre **{name}** a été créé avec succès."


### PR DESCRIPTION
## Summary
- add a favorites feature so users can pin family members from the tree member list and see them in a dedicated section
- preload member favorites in the tree query to avoid per-member queries while rendering the list
- include the supporting translations and small follow-up cleanup needed to ship the feature

## Testing
- not run