### PR TITLE
feat(person): show computed age on profile

### DIFF
--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -390,6 +390,47 @@ class Person implements \Stringable
         return $this;
     }
 
+    public function getAge(): ?int
+    {
+        $referenceDate = $this->getAgeReferenceDate();
+
+        if (!$this->birth instanceof \DateTimeInterface || !$referenceDate instanceof \DateTimeInterface) {
+            return null;
+        }
+
+        return $this->birth->diff($referenceDate)->y;
+    }
+
+    public function isAgeApproximate(): bool
+    {
+        if ($this->getAge() === null) {
+            return false;
+        }
+
+        if ($this->isBirthDayUnsure() || $this->isBirthMonthUnsure() || $this->isBirthYearUnsure()) {
+            return true;
+        }
+
+        if (!$this->isDead()) {
+            return false;
+        }
+
+        return $this->isDeathDayUnsure() || $this->isDeathMonthUnsure() || $this->isDeathYearUnsure();
+    }
+
+    private function getAgeReferenceDate(): ?\DateTimeInterface
+    {
+        if (!$this->birth instanceof \DateTimeInterface) {
+            return null;
+        }
+
+        if ($this->isDead()) {
+            return $this->death;
+        }
+
+        return new \DateTimeImmutable('today');
+    }
+
     public function hasChildren(): bool
     {
         return array_reduce(

--- a/templates/person/base.html.twig
+++ b/templates/person/base.html.twig
@@ -31,21 +31,41 @@
 
                     <h1 class="h2 my-2 text-center">{{ person.fullName }}</h1>
 
+                    {% set age = person.age %}
+                    {% set age_translation_key = person.ageApproximate ? 'person.age.approximate' : 'person.age.value' %}
+                    {% set show_unknown_age = age is null and (not person.birth or (person.isDead and not person.death)) %}
+
                     <div class="card mb-3">
                         <ul class="list-group list-group-flush">
                             {{ macro.list_item('id-card', 'form.field.gender'|trans, 'form.field.gender.value'|trans({ gender: person.gender })) }}
 
                             {% if person.birth %}
-                                {{ macro.list_item('cake-candles', 'form.field.birth_date'|trans, 'calendar'|trans({ date: person.birth })) }}
+                                {% set birth_value %}
+                                    {{ 'calendar'|trans({ date: person.birth }) }}
+                                    {% if age is not null and not person.isDead %}
+                                        <span class="text-body-tertiary">({{ age_translation_key|trans({ age: age }) }})</span>
+                                    {% endif %}
+                                {% endset %}
+                                {{ macro.list_item('cake-candles', 'form.field.birth_date'|trans, birth_value|trim) }}
                             {% endif %}
 
                             {% if person.birthPlace and person.birthPlace != '' %}
                                 {{ macro.list_item('map-marker-alt', 'form.field.birth_place'|trans, person.birthPlace) }}
                             {% endif %}
 
+                            {% if show_unknown_age %}
+                                {{ macro.list_item('hourglass-half', 'label.age'|trans, 'person.age.unknown'|trans) }}
+                            {% endif %}
+
                             {% if person.isDead %}
                                 {% if person.death %}
-                                    {{ macro.list_item('tombstone', 'form.field.death_date'|trans, 'calendar'|trans({ date: person.death })) }}
+                                    {% set death_value %}
+                                        {{ 'calendar'|trans({ date: person.death }) }}
+                                        {% if age is not null %}
+                                            <span class="text-body-tertiary">({{ age_translation_key|trans({ age: age }) }})</span>
+                                        {% endif %}
+                                    {% endset %}
+                                    {{ macro.list_item('tombstone', 'form.field.death_date'|trans, death_value|trim) }}
                                 {% endif %}
                                 
                                 {% if person.deathPlace and person.deathPlace != '' %}

--- a/tests/Entity/PersonTest.php
+++ b/tests/Entity/PersonTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\Person;
+use PHPUnit\Framework\TestCase;
+
+final class PersonTest extends TestCase
+{
+    public function testItComputesAgeForLivingPeople(): void
+    {
+        $person = (new Person())
+            ->setBirth(new \DateTimeImmutable('2000-01-15'));
+
+        self::assertSame(
+            (new \DateTimeImmutable('2000-01-15'))->diff(new \DateTimeImmutable('today'))->y,
+            $person->getAge()
+        );
+        self::assertFalse($person->isAgeApproximate());
+    }
+
+    public function testItComputesAgeAtDeath(): void
+    {
+        $person = (new Person())
+            ->setBirth(new \DateTimeImmutable('1950-06-10'))
+            ->setDeath(new \DateTimeImmutable('2000-06-09'))
+            ->setDead(true);
+
+        self::assertSame(49, $person->getAge());
+        self::assertFalse($person->isAgeApproximate());
+    }
+
+    public function testItMarksAgeAsApproximateWhenBirthIsUncertain(): void
+    {
+        $person = (new Person())
+            ->setBirth(new \DateTimeImmutable('1980-03-20'))
+            ->setBirthYearUnsure(true);
+
+        self::assertNotNull($person->getAge());
+        self::assertTrue($person->isAgeApproximate());
+    }
+
+    public function testItMarksAgeAsApproximateWhenDeathIsUncertain(): void
+    {
+        $person = (new Person())
+            ->setBirth(new \DateTimeImmutable('1980-03-20'))
+            ->setDeath(new \DateTimeImmutable('2020-03-19'))
+            ->setDeathMonthUnsure(true)
+            ->setDead(true);
+
+        self::assertSame(39, $person->getAge());
+        self::assertTrue($person->isAgeApproximate());
+    }
+
+    public function testItReturnsUnknownAgeWithoutBirthDate(): void
+    {
+        $person = new Person();
+
+        self::assertNull($person->getAge());
+        self::assertFalse($person->isAgeApproximate());
+    }
+
+    public function testItReturnsUnknownAgeForDeceasedPeopleWithoutDeathDate(): void
+    {
+        $person = (new Person())
+            ->setBirth(new \DateTimeImmutable('1980-03-20'))
+            ->setDead(true);
+
+        self::assertNull($person->getAge());
+        self::assertFalse($person->isAgeApproximate());
+    }
+}

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -83,6 +83,7 @@ profile:
         success: Your data has been edited.
 label:
     actions: Actions
+    age: Age
     children: Children
     date_uncertain: Uncertain date
     home: Home
@@ -136,6 +137,18 @@ alert:
         }
 calendar: '{date, date, medium}'
 person:
+    age:
+        value: >-
+            {age, plural,
+                =1 {# year old}
+                other {# years old}
+            }
+        approximate: >-
+            ~{age, plural,
+                =1 {# year old}
+                other {# years old}
+            }
+        unknown: Unknown age
     edit:
         success: '**{name}** has been successfully modified.'
     delete:

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -83,6 +83,7 @@ profile:
         success: Vos informations ont bien été modifiées.
 label:
     actions: Actions
+    age: Age
     children: Enfants
     date_uncertain: Date incertaine
     home: Accueil
@@ -137,6 +138,18 @@ alert:
     
 calendar: '{date, date, medium}'
 person:
+    age:
+        value: >-
+            {age, plural,
+                =1 {# an}
+                other {# ans}
+            }
+        approximate: >-
+            ~{age, plural,
+                =1 {# an}
+                other {# ans}
+            }
+        unknown: Âge inconnu
     edit:
         success: '**{name}** a bien été modifié.'
     delete:


### PR DESCRIPTION
## Summary
- add computed age helpers on `Person` for living, deceased, approximate, and unknown-age cases
- show localized age text next to the existing birth and death information on the person profile sidebar
- add focused entity tests to cover the new age calculation rules

## Testing
- `docker compose exec apache php bin/phpunit tests/Entity/PersonTest.php`