### PR TITLE
fix(tree): Use current union field names

### DIFF
--- a/src/Controller/LifeLineController.php
+++ b/src/Controller/LifeLineController.php
@@ -50,7 +50,7 @@ class LifeLineController extends AbstractController
                     'gender' => $person->getGender(),
                     'partner' => $hasPartner ? $union->getPartner($person)->getFullName() : '?',
                     'partner_path' => $hasPartner ? $this->generateUrl('app_person_life_line', ['id' => $union->getPartner($person)->getId()]) : '#',
-                    'place' => $union->getWeddingPlace() ?? 'empty',
+                    'place' => $union->getPlace() ?? 'empty',
                     'year' => $hasUnionDate ? $union->getStartsAt()->format('Y') : 'empty',
                 ]),
             ];

--- a/templates/tree/tree.html.twig
+++ b/templates/tree/tree.html.twig
@@ -19,10 +19,10 @@
             <div class="tree-link tree-link-center"></div>
         </div>
 
-        {% if person.parentUnion.weddingDate is not null %}
+        {% if person.parentUnion.startsAt is not null %}
             <div class="col d-flex flex-nowrap justify-content-center position-relative">
                 <div class="bg-body rounded-pill small border shadow-sm px-2 position-absolute top-0" style="margin-top: -1em; z-index: 1;">
-                    {{ person.parentUnion.weddingDate|date('d/m/Y') }}
+                    {{ person.parentUnion.startsAt|date('d/m/Y') }}
                 </div>
             </div>
         {% endif %}


### PR DESCRIPTION
## Summary
- use `Union::getPlace()` in the life line controller instead of the removed wedding-place accessor
- render parent union dates from `startsAt` in the tree template so existing union dates display again