### PR TITLE
feat(tree): Add advanced missing-union filters

### DIFF
--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -10,7 +10,7 @@ use App\Form\PersonType;
 use App\Form\TreeType;
 use App\Repository\PersonRepository;
 use App\Service\ImageManager;
-use Doctrine\Common\Collections\ArrayCollection;
+use App\Service\PersonManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,6 +27,7 @@ class TreeController extends AbstractController
         private readonly EntityManagerInterface $entityManager,
         private readonly ImageManager $imageManager,
         private readonly PersonRepository $personRepository,
+        private readonly PersonManager $personManager,
     ) {
     }
 
@@ -66,43 +67,39 @@ class TreeController extends AbstractController
         $form = $this->createForm(MembersSearchType::class);
         $form->handleRequest($request);
 
-        $members = $this->personRepository->findByTreeWithFavorites($tree);
-        $members = new ArrayCollection($members);
+        $filters = $form->getData();
+        $name = trim((string) ($filters['name'] ?? ''));
+        $showWithoutOwnUnions = (bool) ($filters['withoutOwnUnions'] ?? false);
+        $showWithoutParentUnion = (bool) ($filters['withoutParentUnion'] ?? false);
+        $advancedFiltersActive = $showWithoutOwnUnions || $showWithoutParentUnion;
 
-        // Filtre de recherche
-        if ($form->isSubmitted() && $form->isValid()) {
-            $name = mb_strtoupper((string) $form->get('name')->getData());
-            $members = $members->filter(function (Person $person) use ($name): bool {
-                if ('' !== $name && '0' !== $name) {
-                    return str_contains(mb_strtoupper($person->getFullName()), $name);
-                }
+        $groupedMembers = $advancedFiltersActive
+            ? []
+            : $this->personManager->findGroupedByTree($tree, $name)
+        ;
 
-                return true;
-            });
-        }
+        $groupedMembersWithoutOwnUnions = $showWithoutOwnUnions
+            ? $this->personManager->findGroupedWithoutOwnUnions($tree, $name)
+            : []
+        ;
 
-        // Tri par ordre alphabétique
-        $orderedMembers = $members->toArray();
-        usort(
-            $orderedMembers,
-            fn ($a, $b): int => strcmp(
-                trim($a->getFullName()),
-                trim($b->getFullName())
-            ));
-
-        // Groupement par première lettre
-        $groupedMembers = array_reduce($orderedMembers, function (array $groupedMembers, Person $person): array {
-            $firstLetter = strtoupper(mb_substr(trim($person->getFullName()), 0, 1));
-            $groupedMembers[$firstLetter][] = $person;
-
-            return $groupedMembers;
-        }, []);
+        $groupedMembersWithoutParentUnion = $showWithoutParentUnion
+            ? $this->personManager->findGroupedWithoutParentUnion($tree, $name)
+            : []
+        ;
 
         return $this->render('tree/show.html.twig', [
             'tree' => $tree,
             'form' => $form->createView(),
             'grouped_members' => $groupedMembers,
-            'members_count' => $members->count(),
+            'grouped_members_without_own_unions' => $groupedMembersWithoutOwnUnions,
+            'grouped_members_without_parent_union' => $groupedMembersWithoutParentUnion,
+            'advanced_filters_active' => $advancedFiltersActive,
+            'show_without_own_unions' => $showWithoutOwnUnions,
+            'show_without_parent_union' => $showWithoutParentUnion,
+            'members_count' => array_sum(array_map('count', $groupedMembers)),
+            'members_without_own_unions_count' => array_sum(array_map('count', $groupedMembersWithoutOwnUnions)),
+            'members_without_parent_union_count' => array_sum(array_map('count', $groupedMembersWithoutParentUnion)),
             'favorites' => $this->personRepository->findFavoritesInTree($tree, $user),
         ]);
     }

--- a/src/Form/MembersSearchType.php
+++ b/src/Form/MembersSearchType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\SearchType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -19,6 +20,14 @@ class MembersSearchType extends AbstractType
                 'attr' => [
                     'placeholder' => 'form.placeholder.search_by_name',
                 ],
+            ])
+            ->add('withoutOwnUnions', CheckboxType::class, [
+                'required' => false,
+                'label' => 'form.field.without_own_unions',
+            ])
+            ->add('withoutParentUnion', CheckboxType::class, [
+                'required' => false,
+                'label' => 'form.field.without_parent_union',
             ])
             ->setMethod(\Symfony\Component\HttpFoundation\Request::METHOD_GET)
         ;

--- a/src/Repository/PersonRepository.php
+++ b/src/Repository/PersonRepository.php
@@ -7,6 +7,7 @@ use App\Entity\Person;
 use App\Entity\Tree;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -54,6 +55,41 @@ class PersonRepository extends ServiceEntityRepository
     /**
      * @return array<int, Person>
      */
+    public function findWithoutOwnUnions(Tree $tree, ?string $name = null): array
+    {
+        $queryBuilder = $this->createTreeMembersQueryBuilder($tree)
+            ->leftJoin('p.unions', 'u')
+            ->andWhere('u.id IS NULL')
+        ;
+
+        $this->applyNameFilter($queryBuilder, $name);
+
+        return $queryBuilder
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+
+    /**
+     * @return array<int, Person>
+     */
+    public function findWithoutParentUnion(Tree $tree, ?string $name = null): array
+    {
+        $queryBuilder = $this->createTreeMembersQueryBuilder($tree)
+            ->andWhere('p.parentUnion IS NULL')
+        ;
+
+        $this->applyNameFilter($queryBuilder, $name);
+
+        return $queryBuilder
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+
+    /**
+     * @return array<int, Person>
+     */
     public function findFavoritesInTree(Tree $tree, User $user): array
     {
         $queryBuilder = $this->getEntityManager()->createQueryBuilder();
@@ -74,17 +110,45 @@ class PersonRepository extends ServiceEntityRepository
     /**
      * @return array<int, Person>
      */
-    public function findByTreeWithFavorites(Tree $tree): array
+    public function findByTreeWithFavorites(Tree $tree, ?string $name = null): array
     {
-        $queryBuilder = $this->createQueryBuilder('p');
-        $query = $queryBuilder
+        $queryBuilder = $this->createTreeMembersQueryBuilder($tree)
             ->select('p, f')
             ->leftJoin('p.favorites', 'f')
-            ->where('p.tree = :tree')
-            ->setParameter('tree', $tree)
-            ->getQuery()
         ;
 
-        return $query->getResult();
+        $this->applyNameFilter($queryBuilder, $name);
+
+        return $queryBuilder
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+
+    private function createTreeMembersQueryBuilder(Tree $tree): QueryBuilder
+    {
+        return $this->createQueryBuilder('p')
+            ->where('p.tree = :tree')
+            ->setParameter('tree', $tree)
+        ;
+    }
+
+    private function applyNameFilter(QueryBuilder $queryBuilder, ?string $name): void
+    {
+        $normalizedName = mb_strtoupper(trim((string) $name));
+
+        if ('' === $normalizedName) {
+            return;
+        }
+
+        $queryBuilder
+            ->andWhere(
+                $queryBuilder->expr()->orX(
+                    'UPPER(CONCAT(COALESCE(p.lastname, \'\'), \' \', COALESCE(p.firstname, \'\'))) LIKE :name',
+                    'UPPER(CONCAT(COALESCE(p.birthName, \'\'), \' \', COALESCE(p.firstname, \'\'))) LIKE :name'
+                )
+            )
+            ->setParameter('name', '%'.$normalizedName.'%')
+        ;
     }
 }

--- a/src/Service/PersonManager.php
+++ b/src/Service/PersonManager.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Person;
+use App\Entity\Tree;
+use App\Repository\PersonRepository;
+
+class PersonManager
+{
+    public function __construct(
+        private readonly PersonRepository $personRepository,
+    ) {
+    }
+
+    /**
+     * @return array<string, array<int, Person>>
+     */
+    public function findGroupedByTree(Tree $tree, ?string $name = null): array
+    {
+        return $this->groupByFirstLetter($this->personRepository->findByTreeWithFavorites($tree, $name));
+    }
+
+    /**
+     * @return array<string, array<int, Person>>
+     */
+    public function findGroupedWithoutOwnUnions(Tree $tree, ?string $name = null): array
+    {
+        return $this->groupByFirstLetter($this->personRepository->findWithoutOwnUnions($tree, $name));
+    }
+
+    /**
+     * @return array<string, array<int, Person>>
+     */
+    public function findGroupedWithoutParentUnion(Tree $tree, ?string $name = null): array
+    {
+        return $this->groupByFirstLetter($this->personRepository->findWithoutParentUnion($tree, $name));
+    }
+
+    /**
+     * @param array<int, Person> $members
+     *
+     * @return array<string, array<int, Person>>
+     */
+    public function groupByFirstLetter(array $members): array
+    {
+        usort(
+            $members,
+            fn (Person $left, Person $right): int => strcmp(
+                trim($left->getFullName()),
+                trim($right->getFullName())
+            )
+        );
+
+        return array_reduce($members, function (array $groupedMembers, Person $person): array {
+            $firstLetter = strtoupper(mb_substr(trim($person->getFullName()), 0, 1));
+            $groupedMembers[$firstLetter][] = $person;
+
+            return $groupedMembers;
+        }, []);
+    }
+}

--- a/templates/person/_avatar.html.twig
+++ b/templates/person/_avatar.html.twig
@@ -19,7 +19,7 @@
                     <div class="row g-1">
                         {% if person.birth %}
                             <div class="col-auto">
-                                <span title="{{ 'calendar'|trans({ date: person.birth }) }}">
+                                <span title="{{ person.birth|date('d/m/Y') }}">
                                     {{ person.birth|date('Y') }}
                                 </span>
                                 {{ include('person/_date_indicator.html.twig', { item: {
@@ -37,7 +37,7 @@
 
                         {% if person.death %}
                             <div class="col-auto">
-                                <span title="{{ 'calendar'|trans({ date: person.death }) }}">
+                                <span title="{{ person.death|date('d/m/Y') }}">
                                     {{ person.death|date('Y') }}
                                 </span>
                                 {{ include('person/_date_indicator.html.twig', { item: {

--- a/templates/person/base.html.twig
+++ b/templates/person/base.html.twig
@@ -41,7 +41,7 @@
 
                             {% if person.birth %}
                                 {% set birth_value %}
-                                    {{ 'calendar'|trans({ date: person.birth }) }}
+                                    {{ person.birth|date('d/m/Y') }}
                                     {% if age is not null and not person.isDead %}
                                         <span class="text-body-tertiary">({{ age_translation_key|trans({ age: age }) }})</span>
                                     {% endif %}
@@ -60,7 +60,7 @@
                             {% if person.isDead %}
                                 {% if person.death %}
                                     {% set death_value %}
-                                        {{ 'calendar'|trans({ date: person.death }) }}
+                                        {{ person.death|date('d/m/Y') }}
                                         {% if age is not null %}
                                             <span class="text-body-tertiary">({{ age_translation_key|trans({ age: age }) }})</span>
                                         {% endif %}

--- a/templates/tree/_grouped_members_list.html.twig
+++ b/templates/tree/_grouped_members_list.html.twig
@@ -1,0 +1,22 @@
+{% from "_includes/macro.html.twig" import alert %}
+
+{% if grouped_members|length %}
+    <div class="bg-body rounded border shadow-sm">
+        {% for letter, members in grouped_members %}
+            <section>
+                <div class="px-4 py-1 fw-bold border-bottom mb-2">{{ letter }}</div>
+                <div class="mb-3">
+                    {% for member in members %}
+                        <div class="tree-member-item px-4 py-1">
+                            {{ include("tree/_member_list_item.html.twig", { member: member }) }}
+                        </div>
+                    {% endfor %}
+                </div>
+            </section>
+        {% endfor %}
+    </div>
+{% else %}
+    <div class="text-secondary px-4 py-1">
+        {{ alert('secondary', empty_message|trans) }}
+    </div>
+{% endif %}

--- a/templates/tree/_member_list_item.html.twig
+++ b/templates/tree/_member_list_item.html.twig
@@ -4,14 +4,14 @@
             <div class="col-auto">
                 {{ include('person/_avatar_thumbnail.html.twig', { person: member, size: 'sm' }) }}
             </div>
-            <div class="col-auto" title="{{ member.birth ? 'calendar'|trans({ date: member.birth }) : '' }}">
+            <div class="col-auto" title="{{ member.birth ? member.birth|date('d/m/Y') : '' }}">
                 <a href="{{ path('app_person_show', { id: member.id }) }}" class="link-body-emphasis link-underline-opacity-0 link-underline-opacity-100-hover">
                     {{ member.fullName }}
                 </a>
             </div>
             
             {% if member.isDead %}
-                <div class="col-auto" title="{{ member.death ? 'calendar'|trans({ date: member.death }) : '' }}">
+                <div class="col-auto" title="{{ member.death ? member.death|date('d/m/Y') : '' }}">
                     <span class="text-secondary">
                         <i class="fa-solid fa-cross"></i>
                     </span>

--- a/templates/tree/_search_form.html.twig
+++ b/templates/tree/_search_form.html.twig
@@ -1,15 +1,41 @@
 {{ form_start(form) }}
-    <div class="input-group mb-1 flex-nowrap">
-        {{ form_row(form.name, { 
-            label: false, 
-            attr: {
-                class: 'form-control rounded-0 rounded-start',
-                value: form.name.vars.data,
-            }, 
-            row_attr: { class: 'mb-0 flex-grow-1' },
-        }) }}
-        <button type="submit" class="btn btn-outline-secondary">
-            <i class="fa-solid fa-magnifying-glass"></i>
-        </button>
+    <div class="row aligns-items-center justify-content-end mb-3">
+        <div class="col-auto order-2 order-md-1">
+            <button
+                class="btn btn-link text-decoration-none px-0"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#advanced-member-filters"
+                aria-expanded="{{ advanced_filters_active ? 'true' : 'false' }}"
+                aria-controls="advanced-member-filters"
+            >
+                <i class="fa-solid fa-sliders"></i>
+                {{ 'label.advanced_filters'|trans }}
+            </button>
+        </div>
+        
+        <div class="col-12 col-md-auto order-1 order-md-2">
+            <div class="input-group flex-nowrap">
+                {{ form_row(form.name, { 
+                    label: false, 
+                    attr: {
+                        class: 'form-control rounded-0 rounded-start',
+                        value: form.name.vars.data,
+                    }, 
+                    row_attr: { class: 'mb-0 flex-grow-1' },
+                }) }}
+                <button type="submit" class="btn btn-outline-secondary">
+                    <i class="fa-solid fa-magnifying-glass"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <div class="collapse{{ advanced_filters_active ? ' show' : '' }}" id="advanced-member-filters">
+        <div class="border rounded p-3 mb-3 bg-body-tertiary">
+            <div class="mb-2 small text-secondary">{{ 'label.diagnostic_filters'|trans }}</div>
+            {{ form_row(form.withoutOwnUnions, { row_attr: { class: 'mb-2' } }) }}
+            {{ form_row(form.withoutParentUnion, { row_attr: { class: 'mb-0' } }) }}
+        </div>
     </div>
 {{ form_end(form) }}

--- a/templates/tree/index.html.twig
+++ b/templates/tree/index.html.twig
@@ -62,7 +62,7 @@
 
                         <div class="row gy-1 gx-3 text-secondary">
                             <div class="col-auto">{{ 'alert.tree_members_count'|trans({ members: tree.members|length }) }}</div>
-                            <div class="col-auto">{{ tree.createdAt ? 'calendar'|trans({'date': tree.createdAt}) : '' }}</div>
+                            <div class="col-auto">{{ tree.createdAt ? tree.createdAt|date('d/m/Y') : '' }}</div>
                         </div>
                     </div>
                 </div>
@@ -75,8 +75,6 @@
                 </div>
             </div>
         </div>
-
-
     </div>
 </section>
 {% endblock %}

--- a/templates/tree/show.html.twig
+++ b/templates/tree/show.html.twig
@@ -13,7 +13,14 @@
                 <h1 class="h3 mb-0">{{ tree.name }}</h1>
                 
                 <span class="text-secondary">
-                    {{ 'alert.tree_members_found_count'|trans({ members: members_count}) }}
+                    {% if advanced_filters_active %}
+                        {{ 'alert.tree_diagnostic_results_count'|trans({
+                            without_own_unions: members_without_own_unions_count,
+                            without_parent_union: members_without_parent_union_count,
+                        }) }}
+                    {% else %}
+                        {{ 'alert.tree_members_found_count'|trans({ members: members_count}) }}
+                    {% endif %}
                 </span>
 
                 <div class="list-group mt-3">
@@ -36,28 +43,40 @@
             </div>
 
             <div class="col">
-                <div class="d-flex justify-content-end">
-                    {% include "tree/_search_form.html.twig" %}
-                </div>
-                {% if grouped_members|length %}
-                    <div class="bg-body rounded border shadow-sm">
-                        {% for letter, members in grouped_members %}
+                {% include "tree/_search_form.html.twig" with { advanced_filters_active: advanced_filters_active } %}
+                {% if advanced_filters_active %}
+                    <div class="vstack gap-4">
+                        {% if show_without_own_unions %}
                             <section>
-                                <div class="px-4 py-1 fw-bold border-bottom mb-2">{{ letter }}</div>
-                                <div class="mb-3">
-                                    {% for member in members %}
-                                        <div class="tree-member-item px-4 py-1">
-                                            {{ include("tree/_member_list_item.html.twig", { member: member }) }}
-                                        </div>
-                                    {% endfor %}
+                                <div class="d-flex align-items-center gap-2 mb-2">
+                                    <h6 class="mb-0">{{ 'label.members_without_own_unions'|trans }}</h6>
+                                    <span class="badge rounded-pill text-bg-secondary">{{ members_without_own_unions_count }}</span>
                                 </div>
+                                {{ include('tree/_grouped_members_list.html.twig', {
+                                    grouped_members: grouped_members_without_own_unions,
+                                    empty_message: 'alert.no_members_without_own_unions_found',
+                                }) }}
                             </section>
-                        {% endfor %}
+                        {% endif %}
+
+                        {% if show_without_parent_union %}
+                            <section>
+                                <div class="d-flex align-items-center gap-2 mb-2">
+                                    <h6 class="mb-0">{{ 'label.members_without_parent_union'|trans }}</h6>
+                                    <span class="badge rounded-pill text-bg-secondary">{{ members_without_parent_union_count }}</span>
+                                </div>
+                                {{ include('tree/_grouped_members_list.html.twig', {
+                                    grouped_members: grouped_members_without_parent_union,
+                                    empty_message: 'alert.no_members_without_parent_union_found',
+                                }) }}
+                            </section>
+                        {% endif %}
                     </div>
                 {% else %}
-                    <div class="text-secondary px-4 py-1">
-                        {{ alert('secondary', 'alert.tree_has_no_member'|trans) }}
-                    </div>
+                    {{ include('tree/_grouped_members_list.html.twig', {
+                        grouped_members: grouped_members,
+                        empty_message: 'alert.tree_has_no_member',
+                    }) }}
                 {% endif %}
             </div>
         </div>

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -35,6 +35,8 @@ form:
         union_start_date: Union start date
         union_end_date: Union end date
         union_place: Union place
+        without_own_unions: Members without own unions
+        without_parent_union: Members without parent union
         type: Type
         comment: Comment
         direct_proof: Direct proof
@@ -98,6 +100,10 @@ label:
     direct_proof: Direct proof
     life_line: Life line
     favorites: Favorites
+    advanced_filters: Advanced filters
+    diagnostic_filters: Diagnostic filters
+    members_without_own_unions: Members without own unions
+    members_without_parent_union: Members without parent union
 title:
     add_child: Add a child
     add_member: Add a member
@@ -129,13 +135,17 @@ alert:
             =1    {One member found}
             other {# members found}
         }
+    tree_diagnostic_results_count: >-
+        Own unions missing: {without_own_unions}, parent union missing: {without_parent_union}
     tree_members_count: >-
         {members, plural,
             =0    {# member}
             =1    {# member}
             other {# members}
         }
-calendar: '{date, date, medium}'
+    no_members_without_own_unions_found: No members without own unions found.
+    no_members_without_parent_union_found: No members without parent union found.
+    calendar: '{date, date, medium}'
 person:
     age:
         value: >-

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -35,6 +35,8 @@ form:
         union_start_date: Date de début de l'union
         union_end_date: Date de fin de l'union
         union_place: Lieu de l'union
+        without_own_unions: Membres sans unions propres
+        without_parent_union: Membres sans union parentale
         type: Type
         comment: Commentaire
         direct_proof: Preuve directe
@@ -98,6 +100,10 @@ label:
     direct_proof: Preuve directe
     life_line: Ligne de vie
     favorites: Favoris
+    advanced_filters: Filtres avancés
+    diagnostic_filters: Filtres de diagnostic
+    members_without_own_unions: Membres sans unions propres
+    members_without_parent_union: Membres sans union parentale
 title:
     add_child: Ajouter un enfant
     add_member: Ajouter un membre
@@ -129,14 +135,18 @@ alert:
             =1    {Un membre trouvé}
             other {# membres trouvés}
         }
+    tree_diagnostic_results_count: >-
+        Sans unions propres : {without_own_unions}, sans union parentale : {without_parent_union}
     tree_members_count: >-
         {members, plural,
             =0    {# membre}
             =1    {# membre}
             other {# membres}
         }
+    no_members_without_own_unions_found: Aucun membre sans unions propres trouvé.
+    no_members_without_parent_union_found: Aucun membre sans union parentale trouvé.
     
-calendar: '{date, date, medium}'
+    calendar: '{date, date, medium}'
 person:
     age:
         value: >-


### PR DESCRIPTION
## Summary
- add a collapsible advanced filters section on the tree page with diagnostics for members without own unions and members without a parent union
- move grouped member retrieval into `PersonManager` and add repository queries so the diagnostics reuse the existing search input and render separate grouped result sections
- format rendered dates explicitly in tree and person templates to avoid the `DateTime could not be converted to string` error triggered while showing member metadata

## Testing
- `docker compose exec apache php bin/console lint:container`
- `docker compose exec apache php bin/console lint:twig templates`
- `docker compose exec apache php bin/console lint:yaml config translations`

## Issue
- Fixes #132