### PR TITLE
feat(tree): add SVG ancestor tree renderer

### DIFF
--- a/assets/controllers/tree_view_controller.js
+++ b/assets/controllers/tree_view_controller.js
@@ -24,6 +24,7 @@ export default class extends Controller {
 
     static values = {
         title: String,
+        messages: Object,
     };
 
     connect() {
@@ -47,7 +48,7 @@ export default class extends Controller {
     }
 
     async exportSvg() {
-        this.showStatus('Preparing SVG export...', false);
+        this.showStatus(this.statusMessage('preparingSvg', 'Preparing SVG export...'), false);
 
         const { serialized } = await this.createExportPayload();
 
@@ -56,7 +57,7 @@ export default class extends Controller {
             `${this.filenameBase}.svg`,
         );
 
-        this.showStatus('SVG export ready.');
+        this.showStatus(this.statusMessage('svgReady', 'SVG export ready.'));
     }
 
     async exportPng() {
@@ -333,7 +334,7 @@ export default class extends Controller {
 
     async exportRaster(format) {
         const label = format.toUpperCase();
-        this.showStatus(`Preparing ${label} export...`, false);
+        this.showStatus(this.statusMessage(`preparing${label[0]}${label.slice(1).toLowerCase()}`, `Preparing ${label} export...`), false);
 
         const { serialized, width, height } = await this.createExportPayload();
         const svgUrl = URL.createObjectURL(new Blob([serialized], { type: 'image/svg+xml;charset=utf-8' }));
@@ -362,7 +363,7 @@ export default class extends Controller {
             }
 
             this.downloadBlob(blob, `${this.filenameBase}.${format}`);
-            this.showStatus(`${label} export ready.`);
+            this.showStatus(this.statusMessage(`${label.toLowerCase()}Ready`, `${label} export ready.`));
         } finally {
             URL.revokeObjectURL(svgUrl);
         }
@@ -527,6 +528,10 @@ export default class extends Controller {
         this.toast.dispose();
         this.toast = new Toast(this.toastTarget);
         this.toast.show();
+    }
+
+    statusMessage(key, fallback) {
+        return this.messagesValue?.[key] || fallback;
     }
 
     get filenameBase() {

--- a/assets/controllers/tree_view_controller.js
+++ b/assets/controllers/tree_view_controller.js
@@ -5,7 +5,7 @@ const CARD_WIDTH = 280;
 const CARD_HEIGHT = 76;
 const AVATAR_SIZE = 44;
 const HORIZONTAL_GAP = 32;
-const LEVEL_GAP = 190;
+const LEVEL_GAP = 112;
 const PADDING = 48;
 const CONNECTOR_STEM = 18;
 const MIN_ZOOM = 0.5;
@@ -150,7 +150,7 @@ export default class extends Controller {
         const group = this.createElement('g', {
             class: 'tree-svg-union',
             fill: 'none',
-            stroke: this.theme.secondaryColor,
+            stroke: this.theme.linkColor,
             'stroke-linecap': 'round',
             'stroke-width': '4',
         });
@@ -502,10 +502,21 @@ export default class extends Controller {
             secondaryColor: this.cssVar(styles, '--bs-secondary-color', '#6c757d'),
             emphasisColor: this.cssVar(styles, '--bs-emphasis-color', '#212529'),
             fontFamily: this.cssVar(styles, '--bs-body-font-family', getComputedStyle(document.body).fontFamily || 'sans-serif'),
+            linkColor: this.opaqueColor(this.cssVar(styles, '--bs-border-color', '#ced4da')),
         };
     }
 
     cssVar(styles, name, fallback) {
         return styles.getPropertyValue(name).trim() || fallback;
+    }
+
+    opaqueColor(color) {
+        const rgbaMatch = color.match(/^rgba\((\d+),\s*(\d+),\s*(\d+),\s*([\d.]+)\)$/i);
+
+        if (rgbaMatch) {
+            return `rgb(${rgbaMatch[1]}, ${rgbaMatch[2]}, ${rgbaMatch[3]})`;
+        }
+
+        return color;
     }
 }

--- a/assets/controllers/tree_view_controller.js
+++ b/assets/controllers/tree_view_controller.js
@@ -369,6 +369,7 @@ export default class extends Controller {
     async createExportPayload() {
         const clone = this.svgTarget.cloneNode(true);
         clone.setAttribute('xmlns', SVG_NS);
+        this.stripExportAnchors(clone);
         await this.inlinePortraits(clone);
 
         return {
@@ -396,6 +397,14 @@ export default class extends Controller {
 
             image.removeAttribute('data-portrait-url');
         }));
+    }
+
+    stripExportAnchors(svg) {
+        const links = Array.from(svg.querySelectorAll('a'));
+
+        links.forEach((link) => {
+            link.replaceWith(...link.childNodes);
+        });
     }
 
     async fetchPortraitDataUrl(url) {

--- a/assets/controllers/tree_view_controller.js
+++ b/assets/controllers/tree_view_controller.js
@@ -1,0 +1,530 @@
+import { Controller } from '@hotwired/stimulus';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const CARD_WIDTH = 280;
+const CARD_HEIGHT = 76;
+const AVATAR_SIZE = 44;
+const HORIZONTAL_GAP = 32;
+const LEVEL_GAP = 190;
+const PADDING = 48;
+const CONNECTOR_STEM = 18;
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 2.5;
+const ZOOM_STEP = 0.2;
+
+export default class extends Controller {
+    static targets = ['data', 'svg', 'status', 'viewport'];
+
+    static values = {
+        title: String,
+    };
+
+    connect() {
+        this.zoom = 1;
+        this.tree = JSON.parse(this.dataTarget.textContent);
+        this.theme = this.readTheme();
+        this.render();
+    }
+
+    zoomIn() {
+        this.updateZoom(this.zoom + ZOOM_STEP);
+    }
+
+    zoomOut() {
+        this.updateZoom(this.zoom - ZOOM_STEP);
+    }
+
+    zoomReset() {
+        this.updateZoom(1);
+    }
+
+    async exportSvg() {
+        this.setStatus('Preparing SVG export...');
+
+        const { serialized } = await this.createExportPayload();
+
+        this.downloadBlob(
+            new Blob([serialized], { type: 'image/svg+xml;charset=utf-8' }),
+            `${this.filenameBase}.svg`,
+        );
+
+        this.setStatus('SVG export ready.');
+    }
+
+    async exportPng() {
+        await this.exportRaster('png');
+    }
+
+    async exportWebp() {
+        await this.exportRaster('webp');
+    }
+
+    render() {
+        this.layout = this.createLayout(this.tree);
+
+        this.svgTarget.replaceChildren();
+        this.svgTarget.setAttribute('xmlns', SVG_NS);
+        this.svgTarget.setAttribute('viewBox', `0 0 ${this.layout.width} ${this.layout.height}`);
+        this.svgTarget.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+
+        const defs = this.createElement('defs');
+        defs.append(this.buildShadowFilter());
+        this.svgTarget.append(defs);
+
+        this.layout.unions.forEach((union) => {
+            this.svgTarget.append(this.renderUnion(union));
+        });
+
+        this.layout.nodes.forEach((entry) => {
+            this.svgTarget.append(this.renderNode(entry, defs));
+        });
+
+        this.updateZoom(this.zoom);
+    }
+
+    createLayout(root) {
+        const measuredTree = this.measure(root);
+        const maxDepth = this.maxDepth(root);
+        const nodes = [];
+        const unions = [];
+
+        this.positionNode(root, measuredTree, PADDING + measuredTree.width / 2, 0, maxDepth, nodes, unions);
+
+        return {
+            nodes,
+            unions,
+            width: measuredTree.width + PADDING * 2,
+            height: maxDepth * LEVEL_GAP + CARD_HEIGHT + PADDING * 2,
+        };
+    }
+
+    measure(node) {
+        if (!node.parentUnion?.parents?.length) {
+            return { width: CARD_WIDTH, parentMeasures: [] };
+        }
+
+        const parentMeasures = node.parentUnion.parents.map((parent) => this.measure(parent));
+        const parentsWidth = this.totalChildrenWidth(parentMeasures);
+
+        return {
+            width: Math.max(CARD_WIDTH, parentsWidth),
+            parentMeasures,
+        };
+    }
+
+    positionNode(node, measuredNode, centerX, generation, maxDepth, nodes, unions) {
+        const levelFromTop = maxDepth - generation - 1;
+        const entry = {
+            node,
+            x: centerX,
+            y: PADDING + levelFromTop * LEVEL_GAP + CARD_HEIGHT / 2,
+        };
+
+        nodes.push(entry);
+
+        if (!node.parentUnion?.parents?.length) {
+            return entry;
+        }
+
+        const parentEntries = [];
+        const totalWidth = this.totalChildrenWidth(measuredNode.parentMeasures);
+        let cursor = centerX - totalWidth / 2;
+
+        node.parentUnion.parents.forEach((parent, index) => {
+            const parentMeasure = measuredNode.parentMeasures[index];
+            const parentCenterX = cursor + parentMeasure.width / 2;
+            parentEntries.push(this.positionNode(parent, parentMeasure, parentCenterX, generation + 1, maxDepth, nodes, unions));
+            cursor += parentMeasure.width + HORIZONTAL_GAP;
+        });
+
+        unions.push({
+            union: node.parentUnion,
+            child: entry,
+            parents: parentEntries,
+        });
+
+        return entry;
+    }
+
+    renderUnion(entry) {
+        const group = this.createElement('g', {
+            class: 'tree-svg-union',
+            fill: 'none',
+            stroke: this.theme.secondaryColor,
+            'stroke-linecap': 'round',
+            'stroke-width': '4',
+        });
+
+        const parentBaseline = entry.parents[0].y + CARD_HEIGHT / 2 + CONNECTOR_STEM;
+        const childTop = entry.child.y - CARD_HEIGHT / 2;
+        const horizontalStart = Math.min(...entry.parents.map((parent) => parent.x));
+        const horizontalEnd = Math.max(...entry.parents.map((parent) => parent.x));
+
+        entry.parents.forEach((parent) => {
+            group.append(this.createElement('line', {
+                x1: parent.x,
+                x2: parent.x,
+                y1: parent.y + CARD_HEIGHT / 2,
+                y2: parentBaseline,
+            }));
+        });
+
+        if (entry.parents.length > 1) {
+            group.append(this.createElement('line', {
+                x1: horizontalStart,
+                x2: horizontalEnd,
+                y1: parentBaseline,
+                y2: parentBaseline,
+            }));
+        }
+
+        group.append(this.createElement('line', {
+            x1: entry.child.x,
+            x2: entry.child.x,
+            y1: parentBaseline,
+            y2: childTop,
+        }));
+
+        if (entry.union.startsAtLabel) {
+            group.append(this.renderUnionLabel(entry.union.startsAtLabel, entry.child.x, parentBaseline, childTop));
+        }
+
+        return group;
+    }
+
+    renderUnionLabel(label, x, baselineY, childTop) {
+        const group = this.createElement('g', {
+            class: 'tree-svg-union-label',
+        });
+        const width = Math.max(84, label.length * 7 + 18);
+        const height = 24;
+        const y = baselineY + (childTop - baselineY - height) / 2;
+
+        group.append(this.createElement('rect', {
+            x: x - width / 2,
+            y,
+            width,
+            height,
+            rx: height / 2,
+            fill: this.theme.bodyBackground,
+            stroke: this.theme.borderColor,
+            'stroke-width': '1',
+        }));
+
+        group.append(this.createElement('text', {
+            x,
+            y: y + 16,
+            'text-anchor': 'middle',
+            'font-size': '12',
+            'font-weight': '600',
+            fill: this.theme.secondaryColor,
+        }, label));
+
+        return group;
+    }
+
+    renderNode(entry, defs) {
+        const group = this.createElement('a', {
+            href: entry.node.profileUrl,
+            class: 'tree-svg-node-link',
+        });
+
+        const nodeGroup = this.createElement('g', {
+            class: 'tree-svg-node',
+            transform: `translate(${entry.x - CARD_WIDTH / 2} ${entry.y - CARD_HEIGHT / 2})`,
+        });
+
+        nodeGroup.append(this.createElement('rect', {
+            width: CARD_WIDTH,
+            height: CARD_HEIGHT,
+            rx: '32',
+            fill: this.theme.bodyBackground,
+            stroke: this.theme.borderColor,
+            'stroke-width': '1',
+            filter: 'url(#tree-node-shadow)',
+        }));
+
+        if (entry.node.portraitUrl) {
+            const clipPathId = `tree-portrait-${entry.node.occurrenceId}`;
+            const clipPath = this.createElement('clipPath', { id: clipPathId });
+            clipPath.append(this.createElement('circle', {
+                cx: 34,
+                cy: 38,
+                r: AVATAR_SIZE / 2,
+            }));
+            defs.append(clipPath);
+
+            nodeGroup.append(this.createElement('image', {
+                x: 12,
+                y: 16,
+                width: AVATAR_SIZE,
+                height: AVATAR_SIZE,
+                href: entry.node.portraitUrl,
+                'data-portrait-url': entry.node.portraitUrl,
+                'clip-path': `url(#${clipPathId})`,
+                preserveAspectRatio: 'xMidYMid slice',
+            }));
+        } else {
+            nodeGroup.append(this.createElement('circle', {
+                cx: 34,
+                cy: 38,
+                r: AVATAR_SIZE / 2,
+                fill: this.placeholderColor(entry.node.gender),
+            }));
+
+            nodeGroup.append(this.createElement('text', {
+                x: 34,
+                y: 44,
+                'text-anchor': 'middle',
+                'font-size': '16',
+                'font-weight': '700',
+                fill: '#fff',
+            }, this.initials(entry.node.fullName)));
+        }
+
+        nodeGroup.append(this.createElement('text', {
+            x: 68,
+            y: 33,
+            'font-size': '15',
+            'font-weight': '700',
+            fill: this.theme.emphasisColor,
+        }, this.truncate(entry.node.fullName, 28)));
+
+        if (entry.node.yearsLabel) {
+            nodeGroup.append(this.createElement('text', {
+                x: 68,
+                y: 54,
+                'font-size': '13',
+                fill: this.theme.secondaryColor,
+            }, entry.node.yearsLabel));
+        }
+
+        group.append(nodeGroup);
+
+        return group;
+    }
+
+    buildShadowFilter() {
+        const filter = this.createElement('filter', {
+            id: 'tree-node-shadow',
+            x: '-20%',
+            y: '-20%',
+            width: '140%',
+            height: '140%',
+        });
+
+        filter.append(this.createElement('feDropShadow', {
+            dx: '0',
+            dy: '2',
+            'stdDeviation': '2',
+            'flood-opacity': '0.18',
+        }));
+
+        return filter;
+    }
+
+    async exportRaster(format) {
+        const label = format.toUpperCase();
+        this.setStatus(`Preparing ${label} export...`);
+
+        const { serialized, width, height } = await this.createExportPayload();
+        const svgUrl = URL.createObjectURL(new Blob([serialized], { type: 'image/svg+xml;charset=utf-8' }));
+
+        try {
+            const image = await this.loadImage(svgUrl);
+            const scale = 2;
+            const canvas = document.createElement('canvas');
+            canvas.width = Math.ceil(width * scale);
+            canvas.height = Math.ceil(height * scale);
+
+            const context = canvas.getContext('2d');
+            if (!context) {
+                throw new Error('Canvas rendering is not available in this browser.');
+            }
+
+            context.scale(scale, scale);
+            context.drawImage(image, 0, 0, width, height);
+
+            const blob = await new Promise((resolve) => {
+                canvas.toBlob(resolve, `image/${format}`);
+            });
+
+            if (!blob) {
+                throw new Error(`${label} export is not supported in this browser.`);
+            }
+
+            this.downloadBlob(blob, `${this.filenameBase}.${format}`);
+            this.setStatus(`${label} export ready.`);
+        } finally {
+            URL.revokeObjectURL(svgUrl);
+        }
+    }
+
+    async createExportPayload() {
+        const clone = this.svgTarget.cloneNode(true);
+        clone.setAttribute('xmlns', SVG_NS);
+        await this.inlinePortraits(clone);
+
+        return {
+            serialized: new XMLSerializer().serializeToString(clone),
+            width: Number.parseFloat(clone.getAttribute('width') ?? `${this.layout.width}`),
+            height: Number.parseFloat(clone.getAttribute('height') ?? `${this.layout.height}`),
+        };
+    }
+
+    async inlinePortraits(svg) {
+        const images = Array.from(svg.querySelectorAll('image[data-portrait-url]'));
+
+        await Promise.all(images.map(async (image) => {
+            const portraitUrl = image.getAttribute('data-portrait-url');
+
+            if (!portraitUrl) {
+                return;
+            }
+
+            const dataUrl = await this.fetchPortraitDataUrl(portraitUrl);
+
+            if (dataUrl) {
+                image.setAttribute('href', dataUrl);
+            }
+
+            image.removeAttribute('data-portrait-url');
+        }));
+    }
+
+    async fetchPortraitDataUrl(url) {
+        try {
+            const image = await this.loadImage(url);
+            const canvas = document.createElement('canvas');
+            canvas.width = 96;
+            canvas.height = 96;
+
+            const context = canvas.getContext('2d');
+            if (!context) {
+                return null;
+            }
+
+            context.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+            return canvas.toDataURL('image/jpeg', 0.82);
+        } catch (error) {
+            return null;
+        }
+    }
+
+    loadImage(src) {
+        return new Promise((resolve, reject) => {
+            const image = new Image();
+            image.crossOrigin = 'anonymous';
+            image.onload = () => resolve(image);
+            image.onerror = () => reject(new Error(`Unable to load image: ${src}`));
+            image.src = src;
+        });
+    }
+
+    updateZoom(nextZoom) {
+        this.zoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, Number.parseFloat(nextZoom.toFixed(2))));
+        this.svgTarget.setAttribute('width', `${Math.ceil(this.layout.width * this.zoom)}`);
+        this.svgTarget.setAttribute('height', `${Math.ceil(this.layout.height * this.zoom)}`);
+    }
+
+    totalChildrenWidth(parentMeasures) {
+        if (!parentMeasures.length) {
+            return CARD_WIDTH;
+        }
+
+        return parentMeasures.reduce((total, measure) => total + measure.width, 0) + HORIZONTAL_GAP * (parentMeasures.length - 1);
+    }
+
+    maxDepth(node) {
+        if (!node.parentUnion?.parents?.length) {
+            return 1;
+        }
+
+        return 1 + Math.max(...node.parentUnion.parents.map((parent) => this.maxDepth(parent)));
+    }
+
+    initials(fullName) {
+        return fullName
+            .split(/\s+/)
+            .filter(Boolean)
+            .slice(0, 2)
+            .map((part) => part[0])
+            .join('');
+    }
+
+    truncate(value, length) {
+        if (value.length <= length) {
+            return value;
+        }
+
+        return `${value.slice(0, length - 1)}...`;
+    }
+
+    placeholderColor(gender) {
+        if (gender === 0) {
+            return '#b6608d';
+        }
+
+        if (gender === 1) {
+            return '#4c7ea4';
+        }
+
+        return '#6c757d';
+    }
+
+    createElement(name, attributes = {}, textContent = null) {
+        const element = document.createElementNS(SVG_NS, name);
+
+        Object.entries(attributes).forEach(([key, value]) => {
+            element.setAttribute(key, `${value}`);
+        });
+
+        if (null !== textContent) {
+            element.textContent = textContent;
+        }
+
+        return element;
+    }
+
+    downloadBlob(blob, filename) {
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        document.body.append(link);
+        link.click();
+        link.remove();
+        window.setTimeout(() => URL.revokeObjectURL(url), 0);
+    }
+
+    setStatus(message) {
+        if (this.hasStatusTarget) {
+            this.statusTarget.textContent = message;
+        }
+    }
+
+    get filenameBase() {
+        return this.titleValue
+            .toLowerCase()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-|-$/g, '') || 'family-tree';
+    }
+
+    readTheme() {
+        const styles = getComputedStyle(document.documentElement);
+
+        return {
+            bodyBackground: this.cssVar(styles, '--bs-body-bg', '#ffffff'),
+            borderColor: this.cssVar(styles, '--bs-border-color', '#ced4da'),
+            secondaryColor: this.cssVar(styles, '--bs-secondary-color', '#6c757d'),
+            emphasisColor: this.cssVar(styles, '--bs-emphasis-color', '#212529'),
+        };
+    }
+
+    cssVar(styles, name, fallback) {
+        return styles.getPropertyValue(name).trim() || fallback;
+    }
+}

--- a/assets/controllers/tree_view_controller.js
+++ b/assets/controllers/tree_view_controller.js
@@ -66,6 +66,8 @@ export default class extends Controller {
         this.svgTarget.setAttribute('xmlns', SVG_NS);
         this.svgTarget.setAttribute('viewBox', `0 0 ${this.layout.width} ${this.layout.height}`);
         this.svgTarget.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+        this.svgTarget.setAttribute('font-family', this.theme.fontFamily);
+        this.svgTarget.setAttribute('font-size', '16');
         const defs = this.createElement('defs');
         this.svgTarget.append(defs);
 
@@ -499,6 +501,7 @@ export default class extends Controller {
             borderColor: this.cssVar(styles, '--bs-border-color', '#ced4da'),
             secondaryColor: this.cssVar(styles, '--bs-secondary-color', '#6c757d'),
             emphasisColor: this.cssVar(styles, '--bs-emphasis-color', '#212529'),
+            fontFamily: this.cssVar(styles, '--bs-body-font-family', getComputedStyle(document.body).fontFamily || 'sans-serif'),
         };
     }
 

--- a/assets/controllers/tree_view_controller.js
+++ b/assets/controllers/tree_view_controller.js
@@ -163,39 +163,57 @@ export default class extends Controller {
 
         const parentBaseline = entry.parents[0].y + CARD_HEIGHT / 2 + CONNECTOR_STEM;
         const childTop = entry.child.y - CARD_HEIGHT / 2;
-        const horizontalStart = Math.min(...entry.parents.map((parent) => parent.x));
-        const horizontalEnd = Math.max(...entry.parents.map((parent) => parent.x));
+        const junctionY = parentBaseline + (childTop - parentBaseline) * 0.45;
 
-        entry.parents.forEach((parent) => {
-            group.append(this.createElement('line', {
-                x1: parent.x,
-                x2: parent.x,
-                y1: parent.y + CARD_HEIGHT / 2,
-                y2: parentBaseline,
+        if (entry.parents.length === 1) {
+            const parent = entry.parents[0];
+            group.append(this.createElement('path', {
+                d: this.buildCurvePath(parent.x, parent.y + CARD_HEIGHT / 2, entry.child.x, childTop, {
+                    startBias: 0.75,
+                    endBias: 0.35,
+                    maxBend: 34,
+                }),
             }));
-        });
+        } else {
+            entry.parents.forEach((parent) => {
+                group.append(this.createElement('path', {
+                    d: this.buildCurvePath(parent.x, parent.y + CARD_HEIGHT / 2, entry.child.x, junctionY, {
+                        startBias: 3,
+                        endBias: 3,
+                        maxBend: 10,
+                    }),
+                }));
+            });
 
-        if (entry.parents.length > 1) {
-            group.append(this.createElement('line', {
-                x1: horizontalStart,
-                x2: horizontalEnd,
-                y1: parentBaseline,
-                y2: parentBaseline,
+            group.append(this.createElement('path', {
+                d: this.buildCurvePath(entry.child.x, junctionY, entry.child.x, childTop, {
+                    startBias: 0.45,
+                    endBias: 0.55,
+                    maxBend: 24,
+                }),
             }));
         }
 
-        group.append(this.createElement('line', {
-            x1: entry.child.x,
-            x2: entry.child.x,
-            y1: parentBaseline,
-            y2: childTop,
-        }));
-
         if (entry.union.startsAtLabel) {
-            group.append(this.renderUnionLabel(entry.union.startsAtLabel, entry.child.x, parentBaseline, childTop));
+            group.append(this.renderUnionLabel(entry.union.startsAtLabel, entry.child.x, parentBaseline, junctionY));
         }
 
         return group;
+    }
+
+    buildCurvePath(fromX, fromY, toX, toY, options = {}) {
+        const verticalDistance = Math.abs(toY - fromY);
+        const maxBend = options.maxBend ?? 28;
+        const bend = Math.min(maxBend, verticalDistance * 0.5);
+        const startBias = options.startBias ?? 0.5;
+        const endBias = options.endBias ?? 0.5;
+
+        return [
+            `M ${fromX} ${fromY}`,
+            `C ${fromX} ${fromY + bend * startBias}`,
+            `${toX} ${toY - bend * endBias}`,
+            `${toX} ${toY}`,
+        ].join(' ');
     }
 
     renderUnionLabel(label, x, baselineY, childTop) {

--- a/assets/controllers/tree_view_controller.js
+++ b/assets/controllers/tree_view_controller.js
@@ -219,10 +219,11 @@ export default class extends Controller {
     renderUnionLabel(label, x, baselineY, childTop) {
         const group = this.createElement('g', {
             class: 'tree-svg-union-label',
+            stroke: 'none',
         });
         const width = Math.max(84, label.length * 7 + 18);
         const height = 24;
-        const y = baselineY + (childTop - baselineY - height) / 2;
+        const y = baselineY - height / 2;
 
         group.append(this.createElement('rect', {
             x: x - width / 2,
@@ -242,6 +243,7 @@ export default class extends Controller {
             'font-size': '12',
             'font-weight': '600',
             fill: this.theme.secondaryColor,
+            stroke: 'none',
         }, label));
 
         return group;

--- a/assets/controllers/tree_view_controller.js
+++ b/assets/controllers/tree_view_controller.js
@@ -2,12 +2,18 @@ import { Controller } from '@hotwired/stimulus';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 const CARD_WIDTH = 280;
-const CARD_HEIGHT = 76;
+const CARD_HEIGHT = 68;
 const AVATAR_SIZE = 44;
 const HORIZONTAL_GAP = 32;
-const LEVEL_GAP = 112;
-const PADDING = 48;
+const LEVEL_GAP = 104;
+const PADDING = 32;
 const CONNECTOR_STEM = 18;
+const CARD_RADIUS = 24;
+const AVATAR_X = 10;
+const AVATAR_Y = 12;
+const TEXT_X = 62;
+const NAME_Y = 31;
+const YEARS_Y = 46;
 const MIN_ZOOM = 0.5;
 const MAX_ZOOM = 2.5;
 const ZOOM_STEP = 0.2;
@@ -237,7 +243,7 @@ export default class extends Controller {
         nodeGroup.append(this.createElement('rect', {
             width: CARD_WIDTH,
             height: CARD_HEIGHT,
-            rx: '32',
+            rx: `${CARD_RADIUS}`,
             fill: this.theme.bodyBackground,
             stroke: this.theme.borderColor,
             'stroke-width': '1',
@@ -247,15 +253,15 @@ export default class extends Controller {
             const clipPathId = `tree-portrait-${entry.node.occurrenceId}`;
             const clipPath = this.createElement('clipPath', { id: clipPathId });
             clipPath.append(this.createElement('circle', {
-                cx: 34,
-                cy: 38,
+                cx: AVATAR_X + AVATAR_SIZE / 2,
+                cy: AVATAR_Y + AVATAR_SIZE / 2,
                 r: AVATAR_SIZE / 2,
             }));
             defs.append(clipPath);
 
             nodeGroup.append(this.createElement('image', {
-                x: 12,
-                y: 16,
+                x: AVATAR_X,
+                y: AVATAR_Y,
                 width: AVATAR_SIZE,
                 height: AVATAR_SIZE,
                 href: entry.node.portraitUrl,
@@ -265,15 +271,15 @@ export default class extends Controller {
             }));
         } else {
             nodeGroup.append(this.createElement('circle', {
-                cx: 34,
-                cy: 38,
+                cx: AVATAR_X + AVATAR_SIZE / 2,
+                cy: AVATAR_Y + AVATAR_SIZE / 2,
                 r: AVATAR_SIZE / 2,
                 fill: this.placeholderColor(entry.node.gender),
             }));
 
             nodeGroup.append(this.createElement('text', {
-                x: 34,
-                y: 44,
+                x: AVATAR_X + AVATAR_SIZE / 2,
+                y: AVATAR_Y + AVATAR_SIZE / 2 + 6,
                 'text-anchor': 'middle',
                 'font-size': '16',
                 'font-weight': '700',
@@ -282,8 +288,8 @@ export default class extends Controller {
         }
 
         nodeGroup.append(this.createElement('text', {
-            x: 68,
-            y: 33,
+            x: TEXT_X,
+            y: NAME_Y,
             'font-size': '15',
             'font-weight': '700',
             fill: this.theme.emphasisColor,
@@ -291,8 +297,8 @@ export default class extends Controller {
 
         if (entry.node.yearsLabel) {
             nodeGroup.append(this.createElement('text', {
-                x: 68,
-                y: 54,
+                x: TEXT_X,
+                y: YEARS_Y,
                 'font-size': '13',
                 fill: this.theme.secondaryColor,
             }, entry.node.yearsLabel));

--- a/assets/controllers/tree_view_controller.js
+++ b/assets/controllers/tree_view_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus';
+import { Toast } from 'bootstrap';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 const CARD_WIDTH = 280;
@@ -19,7 +20,7 @@ const MAX_ZOOM = 2.5;
 const ZOOM_STEP = 0.2;
 
 export default class extends Controller {
-    static targets = ['data', 'svg', 'status', 'viewport'];
+    static targets = ['data', 'svg', 'toast', 'toastBody', 'viewport'];
 
     static values = {
         title: String,
@@ -29,6 +30,7 @@ export default class extends Controller {
         this.zoom = 1;
         this.tree = JSON.parse(this.dataTarget.textContent);
         this.theme = this.readTheme();
+        this.toast = this.hasToastTarget ? new Toast(this.toastTarget) : null;
         this.render();
     }
 
@@ -45,7 +47,7 @@ export default class extends Controller {
     }
 
     async exportSvg() {
-        this.setStatus('Preparing SVG export...');
+        this.showStatus('Preparing SVG export...', false);
 
         const { serialized } = await this.createExportPayload();
 
@@ -54,7 +56,7 @@ export default class extends Controller {
             `${this.filenameBase}.svg`,
         );
 
-        this.setStatus('SVG export ready.');
+        this.showStatus('SVG export ready.');
     }
 
     async exportPng() {
@@ -331,7 +333,7 @@ export default class extends Controller {
 
     async exportRaster(format) {
         const label = format.toUpperCase();
-        this.setStatus(`Preparing ${label} export...`);
+        this.showStatus(`Preparing ${label} export...`, false);
 
         const { serialized, width, height } = await this.createExportPayload();
         const svgUrl = URL.createObjectURL(new Blob([serialized], { type: 'image/svg+xml;charset=utf-8' }));
@@ -360,7 +362,7 @@ export default class extends Controller {
             }
 
             this.downloadBlob(blob, `${this.filenameBase}.${format}`);
-            this.setStatus(`${label} export ready.`);
+            this.showStatus(`${label} export ready.`);
         } finally {
             URL.revokeObjectURL(svgUrl);
         }
@@ -513,10 +515,18 @@ export default class extends Controller {
         window.setTimeout(() => URL.revokeObjectURL(url), 0);
     }
 
-    setStatus(message) {
-        if (this.hasStatusTarget) {
-            this.statusTarget.textContent = message;
+    showStatus(message, autohide = true) {
+        if (!this.toast || !this.hasToastBodyTarget) {
+            return;
         }
+
+        this.toastTarget.setAttribute('data-bs-autohide', autohide ? 'true' : 'false');
+        this.toastTarget.setAttribute('data-bs-delay', autohide ? '2400' : '0');
+        this.toastBodyTarget.textContent = message;
+
+        this.toast.dispose();
+        this.toast = new Toast(this.toastTarget);
+        this.toast.show();
     }
 
     get filenameBase() {

--- a/assets/controllers/tree_view_controller.js
+++ b/assets/controllers/tree_view_controller.js
@@ -66,9 +66,7 @@ export default class extends Controller {
         this.svgTarget.setAttribute('xmlns', SVG_NS);
         this.svgTarget.setAttribute('viewBox', `0 0 ${this.layout.width} ${this.layout.height}`);
         this.svgTarget.setAttribute('preserveAspectRatio', 'xMidYMid meet');
-
         const defs = this.createElement('defs');
-        defs.append(this.buildShadowFilter());
         this.svgTarget.append(defs);
 
         this.layout.unions.forEach((union) => {
@@ -241,7 +239,6 @@ export default class extends Controller {
             fill: this.theme.bodyBackground,
             stroke: this.theme.borderColor,
             'stroke-width': '1',
-            filter: 'url(#tree-node-shadow)',
         }));
 
         if (entry.node.portraitUrl) {
@@ -302,25 +299,6 @@ export default class extends Controller {
         group.append(nodeGroup);
 
         return group;
-    }
-
-    buildShadowFilter() {
-        const filter = this.createElement('filter', {
-            id: 'tree-node-shadow',
-            x: '-20%',
-            y: '-20%',
-            width: '140%',
-            height: '140%',
-        });
-
-        filter.append(this.createElement('feDropShadow', {
-            dx: '0',
-            dy: '2',
-            'stdDeviation': '2',
-            'flood-opacity': '0.18',
-        }));
-
-        return filter;
     }
 
     async exportRaster(format) {

--- a/assets/controllers/tree_view_controller.js
+++ b/assets/controllers/tree_view_controller.js
@@ -226,7 +226,7 @@ export default class extends Controller {
     renderNode(entry, defs) {
         const group = this.createElement('a', {
             href: entry.node.profileUrl,
-            class: 'tree-svg-node-link',
+            class: 'tree-svg-node-link text-decoration-none',
         });
 
         const nodeGroup = this.createElement('g', {

--- a/assets/controllers/tree_view_controller.js
+++ b/assets/controllers/tree_view_controller.js
@@ -100,7 +100,7 @@ export default class extends Controller {
             nodes,
             unions,
             width: measuredTree.width + PADDING * 2,
-            height: maxDepth * LEVEL_GAP + CARD_HEIGHT + PADDING * 2,
+            height: (maxDepth - 1) * LEVEL_GAP + CARD_HEIGHT + PADDING * 2,
         };
     }
 

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -33,7 +33,7 @@ $color-mode-type: media-query;
 // @import "../../vendor/twbs/bootstrap/scss/progress";
 @import "../../vendor/twbs/bootstrap/scss/list-group";
 @import "../../vendor/twbs/bootstrap/scss/close";
-// @import "../../vendor/twbs/bootstrap/scss/toasts";
+@import "../../vendor/twbs/bootstrap/scss/toasts";
 // @import "../../vendor/twbs/bootstrap/scss/modal";
 @import "../../vendor/twbs/bootstrap/scss/tooltip";
 @import "../../vendor/twbs/bootstrap/scss/popover";

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -210,6 +210,32 @@ main.tree-view {
     overflow: auto;
 }
 
+.tree-svg-app {
+    width: 100%;
+}
+
+.tree-svg-viewport {
+    max-width: 100%;
+}
+
+.tree-svg-canvas {
+    display: block;
+}
+
+.tree-svg-node-link {
+    cursor: pointer;
+}
+
+.tree-svg-node-link:hover .tree-svg-node rect,
+.tree-svg-node-link:focus .tree-svg-node rect {
+    stroke: var(--bs-primary);
+    stroke-width: 2;
+}
+
+.tree-svg-status {
+    min-height: 1.25rem;
+}
+
 
 @media (min-width: 768px) {
     main.tree-view {

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -208,10 +208,29 @@ main.tree-view {
     max-width: 100dvw;
     max-height: 100%;
     overflow: auto;
+    position: relative;
 }
 
 .tree-svg-app {
     width: 100%;
+}
+
+.tree-svg-controls {
+    position: absolute;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 2;
+    display: inline-flex;
+    gap: .5rem;
+}
+
+.tree-svg-controls .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0;
 }
 
 .tree-svg-viewport {

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -8,6 +8,7 @@ use App\Form\PersonType;
 use App\Form\TreeOptionsType;
 use App\Service\FavoriteMemberManager;
 use App\Service\ImageManager;
+use App\Service\Tree\AncestorTreeViewModelBuilder;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,12 +16,18 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class PersonController extends AbstractController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator, private readonly EntityManagerInterface $entityManager, private readonly ImageManager $imageManager, private readonly FavoriteMemberManager $favoriteMemberManager,
+        private readonly TranslatorInterface $translator,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly ImageManager $imageManager,
+        private readonly FavoriteMemberManager $favoriteMemberManager,
+        private readonly AncestorTreeViewModelBuilder $ancestorTreeViewModelBuilder,
+        private readonly SerializerInterface $serializer,
     ) {
     }
 
@@ -120,10 +127,13 @@ class PersonController extends AbstractController
     {
         $form = $this->createForm(TreeOptionsType::class);
         $form->handleRequest($request);
+        $depth = max(0, (int) ($form->get('depth')->getData() ?? 4));
+        $tree = $this->ancestorTreeViewModelBuilder->build($person, $depth);
 
         return $this->render('person/show_tree.html.twig', [
             'person' => $person,
             'form' => $form->createView(),
+            'tree_data_json' => $this->serializer->serialize($tree, 'json', ['groups' => ['person_tree']]),
             'tree_view' => true,
         ]);
     }

--- a/src/Service/Tree/AncestorTreeNodeViewModel.php
+++ b/src/Service/Tree/AncestorTreeNodeViewModel.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Tree;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+
+final readonly class AncestorTreeNodeViewModel
+{
+    public function __construct(
+        #[Groups(['person_tree'])]
+        public string $occurrenceId,
+        #[Groups(['person_tree'])]
+        public int $personId,
+        #[Groups(['person_tree'])]
+        public string $fullName,
+        #[Groups(['person_tree'])]
+        public string $profileUrl,
+        #[Groups(['person_tree'])]
+        public ?string $yearsLabel,
+        #[Groups(['person_tree'])]
+        public ?string $portraitUrl,
+        #[Groups(['person_tree'])]
+        public ?int $gender,
+        #[Groups(['person_tree'])]
+        public ?AncestorTreeUnionViewModel $parentUnion,
+    ) {
+    }
+}

--- a/src/Service/Tree/AncestorTreeUnionViewModel.php
+++ b/src/Service/Tree/AncestorTreeUnionViewModel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Tree;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+
+final readonly class AncestorTreeUnionViewModel
+{
+    /**
+     * @param list<AncestorTreeNodeViewModel> $parents
+     */
+    public function __construct(
+        #[Groups(['person_tree'])]
+        public int $unionId,
+        #[Groups(['person_tree'])]
+        public ?string $startsAtLabel,
+        #[Groups(['person_tree'])]
+        public array $parents,
+    ) {
+    }
+}

--- a/src/Service/Tree/AncestorTreeViewModelBuilder.php
+++ b/src/Service/Tree/AncestorTreeViewModelBuilder.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Tree;
+
+use App\Entity\Person;
+use App\Entity\Union;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final readonly class AncestorTreeViewModelBuilder
+{
+    public function __construct(
+        private Packages $packages,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public function build(Person $person, int $maxDepth): AncestorTreeNodeViewModel
+    {
+        return $this->buildNode($person, $maxDepth, 'root', 1);
+    }
+
+    private function buildNode(Person $person, int $maxDepth, string $occurrenceId, int $depth): AncestorTreeNodeViewModel
+    {
+        return new AncestorTreeNodeViewModel(
+            occurrenceId: $occurrenceId,
+            personId: (int) $person->getId(),
+            fullName: $person->getFullName(),
+            profileUrl: $this->urlGenerator->generate('app_person_show', ['id' => $person->getId()]),
+            yearsLabel: $this->formatYearsLabel($person),
+            portraitUrl: $this->buildPortraitUrl($person),
+            gender: $person->getGender(),
+            parentUnion: $this->buildParentUnion($person, $maxDepth, $occurrenceId, $depth),
+        );
+    }
+
+    private function buildParentUnion(Person $person, int $maxDepth, string $occurrenceId, int $depth): ?AncestorTreeUnionViewModel
+    {
+        $parentUnion = $person->getParentUnion();
+
+        if (null === $parentUnion || (0 !== $maxDepth && $depth >= $maxDepth)) {
+            return null;
+        }
+
+        $parents = $parentUnion->getPeople()->toArray();
+        usort($parents, static fn (Person $left, Person $right): int => ($left->getGender() ?? -1) <=> ($right->getGender() ?? -1));
+        $parents = array_values(array_reverse($parents));
+
+        return new AncestorTreeUnionViewModel(
+            unionId: (int) $parentUnion->getId(),
+            startsAtLabel: $this->formatUnionStart($parentUnion),
+            parents: array_map(
+                fn (Person $parent, int $index): AncestorTreeNodeViewModel => $this->buildNode(
+                    $parent,
+                    $maxDepth,
+                    sprintf('%s-%d-%d', $occurrenceId, (int) $parentUnion->getId(), $index),
+                    $depth + 1,
+                ),
+                $parents,
+                array_keys($parents),
+            ),
+        );
+    }
+
+    private function formatYearsLabel(Person $person): ?string
+    {
+        $birthYear = $person->getBirth()?->format('Y');
+        $deathYear = $person->getDeath()?->format('Y');
+
+        if (null === $birthYear && null === $deathYear) {
+            return null;
+        }
+
+        if (null !== $birthYear && null !== $deathYear) {
+            return sprintf('%s • %s', $birthYear, $deathYear);
+        }
+
+        return $birthYear ?? $deathYear;
+    }
+
+    private function buildPortraitUrl(Person $person): ?string
+    {
+        if (null === $person->getPortrait()) {
+            return null;
+        }
+
+        return $this->packages->getUrl('pictures/'.$person->getPortrait());
+    }
+
+    private function formatUnionStart(Union $union): ?string
+    {
+        return $union->getStartsAt()?->format('d/m/Y');
+    }
+}

--- a/templates/person/show_tree.html.twig
+++ b/templates/person/show_tree.html.twig
@@ -30,19 +30,36 @@
 
             <hr>
 
-            <div class="d-grid gap-2 tree-toolbar">
-                <button type="button" class="btn btn-primary" data-action="tree-view#exportSvg">
-                    <i class="fa-solid fa-file-code"></i>
-                    Export SVG
+            <div class="dropdown tree-toolbar">
+                <button
+                    class="btn btn-primary dropdown-toggle w-100"
+                    type="button"
+                    data-bs-toggle="dropdown"
+                    aria-expanded="false"
+                >
+                    <i class="fa-solid fa-download"></i>
+                    Export
                 </button>
-                <button type="button" class="btn btn-outline-primary" data-action="tree-view#exportPng">
-                    <i class="fa-solid fa-file-image"></i>
-                    Export PNG
-                </button>
-                <button type="button" class="btn btn-outline-primary" data-action="tree-view#exportWebp">
-                    <i class="fa-solid fa-image"></i>
-                    Export WebP
-                </button>
+                <ul class="dropdown-menu w-100">
+                    <li>
+                        <button type="button" class="dropdown-item" data-action="tree-view#exportSvg">
+                            <i class="fa-solid fa-file-code"></i>
+                            Export SVG
+                        </button>
+                    </li>
+                    <li>
+                        <button type="button" class="dropdown-item" data-action="tree-view#exportPng">
+                            <i class="fa-solid fa-file-image"></i>
+                            Export PNG
+                        </button>
+                    </li>
+                    <li>
+                        <button type="button" class="dropdown-item" data-action="tree-view#exportWebp">
+                            <i class="fa-solid fa-image"></i>
+                            Export WebP
+                        </button>
+                    </li>
+                </ul>
             </div>
         </div>
     </div>

--- a/templates/person/show_tree.html.twig
+++ b/templates/person/show_tree.html.twig
@@ -10,16 +10,60 @@
 
 {{ include('_includes/main/flashes.html.twig') }}
 
-<section id="tree" class="row gx-0">
+<section
+    id="tree"
+    class="row gx-0"
+    data-controller="tree-view"
+    data-tree-view-title-value="{{ person.fullName|e('html_attr') }}"
+>
     <div class="col-md-auto bg-body" id="tree-option-panel">
         <div class="px-3 py-4">
             {{ include('tree/_tree_form.html.twig', { tree: person.tree }) }}
+
+            <hr>
+
+            <div class="d-grid gap-2 tree-toolbar">
+                <button type="button" class="btn btn-outline-secondary" data-action="tree-view#zoomOut">
+                    <i class="fa-solid fa-magnifying-glass-minus"></i>
+                    Zoom out
+                </button>
+                <button type="button" class="btn btn-outline-secondary" data-action="tree-view#zoomReset">
+                    <i class="fa-solid fa-expand"></i>
+                    Reset zoom
+                </button>
+                <button type="button" class="btn btn-outline-secondary" data-action="tree-view#zoomIn">
+                    <i class="fa-solid fa-magnifying-glass-plus"></i>
+                    Zoom in
+                </button>
+            </div>
+
+            <hr>
+
+            <div class="d-grid gap-2 tree-toolbar">
+                <button type="button" class="btn btn-primary" data-action="tree-view#exportSvg">
+                    <i class="fa-solid fa-file-code"></i>
+                    Export SVG
+                </button>
+                <button type="button" class="btn btn-outline-primary" data-action="tree-view#exportPng">
+                    <i class="fa-solid fa-file-image"></i>
+                    Export PNG
+                </button>
+                <button type="button" class="btn btn-outline-primary" data-action="tree-view#exportWebp">
+                    <i class="fa-solid fa-image"></i>
+                    Export WebP
+                </button>
+            </div>
         </div>
     </div>
     <div class="col-md d-flex justify-content-center align-items-center mh-100" id="tree-view-panel">
-        <div class="text-center" style="width: inherit; height: inherit; max-height: inherit;">
-            <div class="m-3 d-inline-block">
-                {{ include('tree/tree.html.twig', { person: person, depth: 1, max_depth: form.depth.vars.data|default(4) }) }}
+        <div
+            class="tree-svg-app text-center"
+            style="width: inherit; height: inherit; max-height: inherit;"
+        >
+            <script type="application/json" data-tree-view-target="data">{{ tree_data_json|replace({'</': '<\/'})|raw }}</script>
+            <div class="tree-svg-status small text-secondary mt-3 mb-0" data-tree-view-target="status"></div>
+            <div class="m-3 d-inline-block tree-svg-viewport" data-tree-view-target="viewport">
+                <svg class="tree-svg-canvas" data-tree-view-target="svg" role="img" aria-label="{{ 'title.tree_of'|trans({ name: person.fullName }) }}"></svg>
             </div>
         </div>
     </div>

--- a/templates/person/show_tree.html.twig
+++ b/templates/person/show_tree.html.twig
@@ -15,6 +15,14 @@
     class="row gx-0"
     data-controller="tree-view"
     data-tree-view-title-value="{{ person.fullName|e('html_attr') }}"
+    data-tree-view-messages-value="{{ {
+        preparingSvg: 'tree.export.preparing_svg'|trans,
+        svgReady: 'tree.export.svg_ready'|trans,
+        preparingPng: 'tree.export.preparing_png'|trans,
+        pngReady: 'tree.export.png_ready'|trans,
+        preparingWebp: 'tree.export.preparing_webp'|trans,
+        webpReady: 'tree.export.webp_ready'|trans
+    }|json_encode|e('html_attr') }}"
 >
     <div class="col-md-auto bg-body" id="tree-option-panel">
         <div class="px-3 py-4">

--- a/templates/person/show_tree.html.twig
+++ b/templates/person/show_tree.html.twig
@@ -23,23 +23,6 @@
             <hr>
 
             <div class="d-grid gap-2 tree-toolbar">
-                <button type="button" class="btn btn-outline-secondary" data-action="tree-view#zoomOut">
-                    <i class="fa-solid fa-magnifying-glass-minus"></i>
-                    Zoom out
-                </button>
-                <button type="button" class="btn btn-outline-secondary" data-action="tree-view#zoomReset">
-                    <i class="fa-solid fa-expand"></i>
-                    Reset zoom
-                </button>
-                <button type="button" class="btn btn-outline-secondary" data-action="tree-view#zoomIn">
-                    <i class="fa-solid fa-magnifying-glass-plus"></i>
-                    Zoom in
-                </button>
-            </div>
-
-            <hr>
-
-            <div class="d-grid gap-2 tree-toolbar">
                 <button type="button" class="btn btn-primary" data-action="tree-view#exportSvg">
                     <i class="fa-solid fa-file-code"></i>
                     Export SVG
@@ -56,6 +39,35 @@
         </div>
     </div>
     <div class="col-md d-flex justify-content-center align-items-center mh-100" id="tree-view-panel">
+        <div class="tree-svg-controls" role="toolbar" aria-label="Tree zoom controls">
+            <button
+                type="button"
+                class="btn btn-outline-secondary"
+                data-action="tree-view#zoomOut"
+                title="Zoom out"
+                aria-label="Zoom out"
+            >
+                <i class="fa-solid fa-magnifying-glass-minus" aria-hidden="true"></i>
+            </button>
+            <button
+                type="button"
+                class="btn btn-outline-secondary"
+                data-action="tree-view#zoomReset"
+                title="Reset zoom"
+                aria-label="Reset zoom"
+            >
+                <i class="fa-solid fa-expand" aria-hidden="true"></i>
+            </button>
+            <button
+                type="button"
+                class="btn btn-outline-secondary"
+                data-action="tree-view#zoomIn"
+                title="Zoom in"
+                aria-label="Zoom in"
+            >
+                <i class="fa-solid fa-magnifying-glass-plus" aria-hidden="true"></i>
+            </button>
+        </div>
         <div
             class="tree-svg-app text-center"
             style="width: inherit; height: inherit; max-height: inherit;"

--- a/templates/person/show_tree.html.twig
+++ b/templates/person/show_tree.html.twig
@@ -39,6 +39,17 @@
         </div>
     </div>
     <div class="col-md d-flex justify-content-center align-items-center mh-100" id="tree-view-panel">
+        <div class="toast-container position-absolute top-0 end-0 p-3">
+            <div
+                class="toast"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+                data-tree-view-target="toast"
+            >
+                <div class="toast-body" data-tree-view-target="toastBody"></div>
+            </div>
+        </div>
         <div class="tree-svg-controls" role="toolbar" aria-label="Tree zoom controls">
             <button
                 type="button"
@@ -73,7 +84,6 @@
             style="width: inherit; height: inherit; max-height: inherit;"
         >
             <script type="application/json" data-tree-view-target="data">{{ tree_data_json|replace({'</': '<\/'})|raw }}</script>
-            <div class="tree-svg-status small text-secondary mt-3 mb-0" data-tree-view-target="status"></div>
             <div class="m-3 d-inline-block tree-svg-viewport" data-tree-view-target="viewport">
                 <svg class="tree-svg-canvas" data-tree-view-target="svg" role="img" aria-label="{{ 'title.tree_of'|trans({ name: person.fullName }) }}"></svg>
             </div>

--- a/tests/Service/Tree/AncestorTreeViewModelBuilderTest.php
+++ b/tests/Service/Tree/AncestorTreeViewModelBuilderTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service\Tree;
+
+use App\Entity\Person;
+use App\Entity\Tree;
+use App\Entity\Union;
+use App\Service\Tree\AncestorTreeViewModelBuilder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Asset\Package;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class AncestorTreeViewModelBuilderTest extends TestCase
+{
+    public function testItBuildsADepthLimitedAncestorTree(): void
+    {
+        $builder = new AncestorTreeViewModelBuilder(
+            new Packages(new Package(new EmptyVersionStrategy())),
+            $this->createUrlGenerator(),
+        );
+
+        $tree = (new Tree())
+            ->setName('Test tree')
+            ->setCreatedAt(new \DateTimeImmutable())
+        ;
+
+        $grandFather = $this->createPerson(1, $tree, 'John', 'Doe', Person::MALE, null, new \DateTimeImmutable('1940-01-01'));
+        $grandMother = $this->createPerson(2, $tree, 'Jane', 'Doe', Person::FEMALE, 'jane.jpg', new \DateTimeImmutable('1942-01-01'));
+        $father = $this->createPerson(3, $tree, 'Jack', 'Doe', Person::MALE, null, new \DateTimeImmutable('1970-01-01'));
+        $child = $this->createPerson(4, $tree, 'Jill', 'Doe', Person::FEMALE, null, new \DateTimeImmutable('2000-01-01'));
+
+        $grandParentUnion = $this->createUnion(11, $grandFather, $grandMother, $father, new \DateTimeImmutable('1969-04-20'));
+        $parentUnion = $this->createUnion(12, $father, $grandMother, $child, new \DateTimeImmutable('1999-05-21'));
+
+        $father->setParentUnion($grandParentUnion);
+        $child->setParentUnion($parentUnion);
+
+        $viewModel = $builder->build($child, 2);
+
+        self::assertSame('root', $viewModel->occurrenceId);
+        self::assertSame(4, $viewModel->personId);
+        self::assertSame('/person/4', $viewModel->profileUrl);
+        self::assertSame('2000', $viewModel->yearsLabel);
+        self::assertNotNull($viewModel->parentUnion);
+        self::assertSame('21/05/1999', $viewModel->parentUnion->startsAtLabel);
+        self::assertCount(2, $viewModel->parentUnion->parents);
+        self::assertSame(3, $viewModel->parentUnion->parents[0]->personId);
+        self::assertSame(2, $viewModel->parentUnion->parents[1]->personId);
+        self::assertNull($viewModel->parentUnion->parents[0]->parentUnion);
+        self::assertSame('pictures/jane.jpg', $viewModel->parentUnion->parents[1]->portraitUrl);
+    }
+
+    public function testItBuildsUnlimitedDepthWhenDepthIsZero(): void
+    {
+        $builder = new AncestorTreeViewModelBuilder(
+            new Packages(new Package(new EmptyVersionStrategy())),
+            $this->createUrlGenerator(),
+        );
+
+        $tree = (new Tree())
+            ->setName('Test tree')
+            ->setCreatedAt(new \DateTimeImmutable())
+        ;
+
+        $grandFather = $this->createPerson(1, $tree, 'John', 'Doe', Person::MALE, null, new \DateTimeImmutable('1940-01-01'));
+        $grandMother = $this->createPerson(2, $tree, 'Jane', 'Doe', Person::FEMALE, null, new \DateTimeImmutable('1942-01-01'));
+        $father = $this->createPerson(3, $tree, 'Jack', 'Doe', Person::MALE, null, new \DateTimeImmutable('1970-01-01'));
+        $child = $this->createPerson(4, $tree, 'Jill', 'Doe', Person::FEMALE, null, new \DateTimeImmutable('2000-01-01'));
+
+        $grandParentUnion = $this->createUnion(11, $grandFather, $grandMother, $father);
+        $parentUnion = $this->createUnion(12, $father, $grandMother, $child);
+
+        $father->setParentUnion($grandParentUnion);
+        $child->setParentUnion($parentUnion);
+
+        $viewModel = $builder->build($child, 0);
+
+        self::assertNotNull($viewModel->parentUnion);
+        self::assertNotNull($viewModel->parentUnion->parents[0]->parentUnion);
+        self::assertSame(1, $viewModel->parentUnion->parents[0]->parentUnion->parents[0]->personId);
+        self::assertSame(2, $viewModel->parentUnion->parents[0]->parentUnion->parents[1]->personId);
+    }
+
+    private function createPerson(
+        int $id,
+        Tree $tree,
+        string $firstname,
+        string $lastname,
+        int $gender,
+        ?string $portrait,
+        ?\DateTimeInterface $birth,
+    ): Person {
+        $person = (new Person())
+            ->setTree($tree)
+            ->setFirstname($firstname)
+            ->setLastname($lastname)
+            ->setGender($gender)
+            ->setPortrait($portrait)
+            ->setBirth($birth)
+        ;
+
+        $this->setId($person, $id);
+
+        return $person;
+    }
+
+    private function createUnion(int $id, Person $parentA, Person $parentB, Person $child, ?\DateTimeImmutable $startsAt = null): Union
+    {
+        $union = (new Union())
+            ->addPerson($parentA)
+            ->addPerson($parentB)
+            ->addChild($child)
+            ->setStartsAt($startsAt)
+        ;
+
+        $this->setId($union, $id);
+
+        return $union;
+    }
+
+    private function createUrlGenerator(): UrlGeneratorInterface
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator
+            ->method('generate')
+            ->willReturnCallback(static fn (string $route, array $parameters = []): string => match ($route) {
+                'app_person_show' => sprintf('/person/%d', $parameters['id']),
+                default => '/',
+            })
+        ;
+
+        return $urlGenerator;
+    }
+
+    private function setId(object $entity, int $id): void
+    {
+        $reflectionProperty = new \ReflectionProperty($entity, 'id');
+        $reflectionProperty->setValue($entity, $id);
+    }
+}

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -178,6 +178,13 @@ tree:
     add_member:
         success: '**{name}** has been successfully added to the tree.'
         error: '**{name}** has not been added to the tree.'
+    export:
+        preparing_svg: Preparing SVG export...
+        svg_ready: SVG export ready.
+        preparing_png: Preparing PNG export...
+        png_ready: PNG export ready.
+        preparing_webp: Preparing WebP export...
+        webp_ready: WebP export ready.
 union:
     new:
         success: 'The union has been successfully created.'

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -179,6 +179,13 @@ tree:
     add_member:
         success: "**{name}** a bien été ajouté à l'arbre."
         error: "**{name}** n'a pas été ajouté à l'arbre."
+    export:
+        preparing_svg: Préparation de l'export SVG...
+        svg_ready: L'export SVG est prêt.
+        preparing_png: Préparation de l'export PNG...
+        png_ready: L'export PNG est prêt.
+        preparing_webp: Préparation de l'export WebP...
+        webp_ready: L'export WebP est prêt.
 union:
     new:
         success: "L'union a bien été créée."


### PR DESCRIPTION
## Summary
- replace the Twig ancestor tree on the person page with an SVG-first Stimulus renderer backed by a dedicated ancestor tree view model
- add client-side SVG, PNG, and WebP export with embedded portraits, localized export toasts, and exported SVG cleanup
- polish the tree UI with curved connectors, tighter canvas spacing, viewport zoom controls, and an export dropdown

## Testing
- not run for this final PR step

Fixes #155