### PR TITLE
feat(stats): Add tree and ancestor branch statistics pages

### DIFF
--- a/assets/controllers.json
+++ b/assets/controllers.json
@@ -1,5 +1,11 @@
 {
     "controllers": {
+        "@symfony/ux-chartjs": {
+            "chart": {
+                "enabled": true,
+                "fetch": "eager"
+            }
+        },
         "@symfony/ux-turbo": {
             "turbo-core": {
                 "enabled": true,

--- a/assets/controllers/chart_mode_controller.js
+++ b/assets/controllers/chart_mode_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['toggle', 'scrollArea', 'chart'];
+
+    connect() {
+        this.update();
+    }
+
+    update() {
+        const extended = this.toggleTarget.checked;
+
+        this.scrollAreaTargets.forEach((scrollArea) => {
+            scrollArea.classList.toggle('overflow-x-auto', extended);
+        });
+
+        this.chartTargets.forEach((chart) => {
+            const years = Number.parseInt(chart.dataset.years ?? '0', 10);
+            chart.style.minWidth = extended ? `max(100%, ${years}rem)` : '100%';
+        });
+
+        requestAnimationFrame(() => {
+            window.dispatchEvent(new Event('resize'));
+        });
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "symfony/string": "8.0.*",
         "symfony/translation": "8.0.*",
         "symfony/twig-bundle": "8.0.*",
+        "symfony/ux-chartjs": "^3.0",
         "symfony/ux-turbo": "^2.24",
         "symfony/validator": "8.0.*",
         "symfony/web-link": "8.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f2476e6ef07f7cf3712d00b968bb580",
+    "content-hash": "b0ce8fa4947d4ef96ff3f9cd90cfe88a",
     "packages": [
         {
             "name": "composer/semver",
@@ -7370,6 +7370,90 @@
             "time": "2026-03-30T15:14:47+00:00"
         },
         {
+            "name": "symfony/ux-chartjs",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/ux-chartjs.git",
+                "reference": "48e08bff59a9440c1b3b39cb6d7241a294c7fcb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/ux-chartjs/zipball/48e08bff59a9440c1b3b39cb6d7241a294c7fcb6",
+                "reference": "48e08bff59a9440c1b3b39cb6d7241a294c7fcb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/stimulus-bundle": "^2.9.1|^3.0"
+            },
+            "conflict": {
+                "symfony/flex": "<1.13"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.1|^12.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/twig-bundle": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/ux",
+                    "name": "symfony/ux"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\UX\\Chartjs\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Titouan Galopin",
+                    "email": "galopintitouan@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Chart.js integration for Symfony",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "symfony-ux"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/ux-chartjs/tree/v3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-09T22:56:44+00:00"
+        },
+        {
             "name": "symfony/ux-turbo",
             "version": "v2.34.0",
             "source": {
@@ -12045,7 +12129,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "ext-ctype": "*",
         "ext-iconv": "*"
     },

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -16,4 +16,5 @@ return [
     Symfony\UX\StimulusBundle\StimulusBundle::class => ['all' => true],
     Symfony\UX\Turbo\TurboBundle::class => ['all' => true],
     Symfonycasts\SassBundle\SymfonycastsSassBundle::class => ['all' => true],
+    Symfony\UX\Chartjs\ChartjsBundle::class => ['all' => true],
 ];

--- a/importmap.php
+++ b/importmap.php
@@ -31,4 +31,7 @@ return [
     '@popperjs/core' => [
         'version' => '2.11.8',
     ],
+    'chart.js' => [
+        'version' => '3.9.1',
+    ],
 ];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,6 @@
          backupGlobals="false"
          colors="true"
          bootstrap="tests/bootstrap.php"
-         convertDeprecationsToExceptions="false"
 >
     <php>
         <ini name="display_errors" value="1" />
@@ -23,16 +22,9 @@
         </testsuite>
     </testsuites>
 
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
-    </coverage>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-    </listeners>
-
-    <extensions>
-    </extensions>
+    </source>
 </phpunit>

--- a/src/Controller/PersonController.php
+++ b/src/Controller/PersonController.php
@@ -9,6 +9,8 @@ use App\Form\TreeOptionsType;
 use App\Service\FavoriteMemberManager;
 use App\Service\ImageManager;
 use App\Service\Tree\AncestorTreeViewModelBuilder;
+use App\Service\Tree\PersonAncestorBranchMemberCollector;
+use App\Service\Tree\TreeStatisticsBuilder;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,6 +20,8 @@ use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\UX\Chartjs\Builder\ChartBuilderInterface;
+use Symfony\UX\Chartjs\Model\Chart;
 
 class PersonController extends AbstractController
 {
@@ -27,7 +31,10 @@ class PersonController extends AbstractController
         private readonly ImageManager $imageManager,
         private readonly FavoriteMemberManager $favoriteMemberManager,
         private readonly AncestorTreeViewModelBuilder $ancestorTreeViewModelBuilder,
+        private readonly PersonAncestorBranchMemberCollector $personAncestorBranchMemberCollector,
+        private readonly TreeStatisticsBuilder $treeStatisticsBuilder,
         private readonly SerializerInterface $serializer,
+        private readonly ChartBuilderInterface $chartBuilder,
     ) {
     }
 
@@ -138,6 +145,31 @@ class PersonController extends AbstractController
         ]);
     }
 
+    #[Route('/person/{id}/statistics', name: 'app_person_statistics', methods: ['GET'])]
+    #[IsGranted('view', 'person')]
+    public function statistics(Person $person): Response
+    {
+        $branchMembers = $this->personAncestorBranchMemberCollector->collect($person);
+        $statistics = $this->treeStatisticsBuilder->buildFromMembers($branchMembers);
+
+        return $this->render('person/statistics.html.twig', [
+            'person' => $person,
+            'statistics' => $statistics,
+            'births_chart' => $this->createYearlyChart(
+                $this->translator->trans('tree.statistics.births.chart_label'),
+                $statistics['births_by_year'],
+                'rgb(25, 135, 84)',
+                'rgba(25, 135, 84, 0.18)',
+            ),
+            'deaths_chart' => $this->createYearlyChart(
+                $this->translator->trans('tree.statistics.deaths.chart_label'),
+                $statistics['deaths_by_year'],
+                'rgb(220, 53, 69)',
+                'rgba(220, 53, 69, 0.18)',
+            ),
+        ]);
+    }
+
     #[Route('/person/{id}/favorite', name: 'app_person_favorite', methods: [Request::METHOD_GET])]
     public function favorite(Person $person, #[CurrentUser()] User $user): Response
     {
@@ -162,5 +194,48 @@ class PersonController extends AbstractController
         );
 
         return $this->redirectToRoute('app_tree_show', ['id' => $person->getTree()->getId()]);
+    }
+
+    /**
+     * @param array{labels: list<string>, data: list<int>} $dataset
+     */
+    private function createYearlyChart(string $label, array $dataset, string $borderColor, string $backgroundColor): ?Chart
+    {
+        if ([] === $dataset['labels']) {
+            return null;
+        }
+
+        $chart = $this->chartBuilder->createChart(Chart::TYPE_LINE);
+        $chart->setData([
+            'labels' => $dataset['labels'],
+            'datasets' => [[
+                'label' => $label,
+                'data' => $dataset['data'],
+                'borderColor' => $borderColor,
+                'backgroundColor' => $backgroundColor,
+                'fill' => true,
+                'tension' => 0.25,
+                'pointRadius' => 3,
+                'pointHoverRadius' => 5,
+            ]],
+        ]);
+        $chart->setOptions([
+            'maintainAspectRatio' => false,
+            'scales' => [
+                'y' => [
+                    'beginAtZero' => true,
+                    'ticks' => [
+                        'precision' => 0,
+                    ],
+                ],
+            ],
+            'plugins' => [
+                'legend' => [
+                    'display' => false,
+                ],
+            ],
+        ]);
+
+        return $chart;
     }
 }

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -11,6 +11,7 @@ use App\Form\TreeType;
 use App\Repository\PersonRepository;
 use App\Service\ImageManager;
 use App\Service\PersonManager;
+use App\Service\Tree\TreeStatisticsBuilder;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,6 +20,8 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\UX\Chartjs\Builder\ChartBuilderInterface;
+use Symfony\UX\Chartjs\Model\Chart;
 
 class TreeController extends AbstractController
 {
@@ -28,6 +31,8 @@ class TreeController extends AbstractController
         private readonly ImageManager $imageManager,
         private readonly PersonRepository $personRepository,
         private readonly PersonManager $personManager,
+        private readonly TreeStatisticsBuilder $treeStatisticsBuilder,
+        private readonly ChartBuilderInterface $chartBuilder,
     ) {
     }
 
@@ -101,6 +106,30 @@ class TreeController extends AbstractController
             'members_without_own_unions_count' => array_sum(array_map('count', $groupedMembersWithoutOwnUnions)),
             'members_without_parent_union_count' => array_sum(array_map('count', $groupedMembersWithoutParentUnion)),
             'favorites' => $this->personRepository->findFavoritesInTree($tree, $user),
+        ]);
+    }
+
+    #[Route('/project/{id}/statistics', name: 'app_tree_statistics', methods: ['GET'])]
+    #[IsGranted('view', 'tree')]
+    public function statistics(Tree $tree): Response
+    {
+        $statistics = $this->treeStatisticsBuilder->build($tree);
+
+        return $this->render('tree/statistics.html.twig', [
+            'tree' => $tree,
+            'statistics' => $statistics,
+            'births_chart' => $this->createYearlyChart(
+                $this->translator->trans('tree.statistics.births.chart_label'),
+                $statistics['births_by_year'],
+                'rgb(25, 135, 84)',
+                'rgba(25, 135, 84, 0.18)',
+            ),
+            'deaths_chart' => $this->createYearlyChart(
+                $this->translator->trans('tree.statistics.deaths.chart_label'),
+                $statistics['deaths_by_year'],
+                'rgb(220, 53, 69)',
+                'rgba(220, 53, 69, 0.18)',
+            ),
         ]);
     }
 
@@ -190,5 +219,48 @@ class TreeController extends AbstractController
             'form' => $form,
             'tree' => $tree,
         ]);
+    }
+
+    /**
+     * @param array{labels: list<string>, data: list<int>} $dataset
+     */
+    private function createYearlyChart(string $label, array $dataset, string $borderColor, string $backgroundColor): ?Chart
+    {
+        if ([] === $dataset['labels']) {
+            return null;
+        }
+
+        $chart = $this->chartBuilder->createChart(Chart::TYPE_LINE);
+        $chart->setData([
+            'labels' => $dataset['labels'],
+            'datasets' => [[
+                'label' => $label,
+                'data' => $dataset['data'],
+                'borderColor' => $borderColor,
+                'backgroundColor' => $backgroundColor,
+                'fill' => true,
+                'tension' => 0.25,
+                'pointRadius' => 3,
+                'pointHoverRadius' => 5,
+            ]],
+        ]);
+        $chart->setOptions([
+            'maintainAspectRatio' => false,
+            'scales' => [
+                'y' => [
+                    'beginAtZero' => true,
+                    'ticks' => [
+                        'precision' => 0,
+                    ],
+                ],
+            ],
+            'plugins' => [
+                'legend' => [
+                    'display' => false,
+                ],
+            ],
+        ]);
+
+        return $chart;
     }
 }

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -403,7 +403,7 @@ class Person implements \Stringable
 
     public function isAgeApproximate(): bool
     {
-        if ($this->getAge() === null) {
+        if (null === $this->getAge()) {
             return false;
         }
 

--- a/src/Repository/PersonRepository.php
+++ b/src/Repository/PersonRepository.php
@@ -138,6 +138,22 @@ class PersonRepository extends ServiceEntityRepository
         ;
     }
 
+    /**
+     * @return array<int, Person>
+     */
+    public function findByTreeForStatisticsGraph(Tree $tree): array
+    {
+        return $this->createTreeMembersQueryBuilder($tree)
+            ->select('DISTINCT p, pu, parents')
+            ->leftJoin('p.parentUnion', 'pu')
+            ->leftJoin('pu.people', 'parents')
+            ->orderBy('p.lastname', 'ASC')
+            ->addOrderBy('p.firstname', 'ASC')
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+
     private function createTreeMembersQueryBuilder(Tree $tree): QueryBuilder
     {
         return $this->createQueryBuilder('p')

--- a/src/Repository/PersonRepository.php
+++ b/src/Repository/PersonRepository.php
@@ -125,6 +125,19 @@ class PersonRepository extends ServiceEntityRepository
         ;
     }
 
+    /**
+     * @return array<int, Person>
+     */
+    public function findByTreeForStatistics(Tree $tree): array
+    {
+        return $this->createTreeMembersQueryBuilder($tree)
+            ->orderBy('p.lastname', 'ASC')
+            ->addOrderBy('p.firstname', 'ASC')
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+
     private function createTreeMembersQueryBuilder(Tree $tree): QueryBuilder
     {
         return $this->createQueryBuilder('p')

--- a/src/Service/Tree/PersonAncestorBranchMemberCollector.php
+++ b/src/Service/Tree/PersonAncestorBranchMemberCollector.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Service\Tree;
+
+use App\Entity\Person;
+
+class PersonAncestorBranchMemberCollector
+{
+    /**
+     * @return array<int, Person>
+     */
+    public function collect(Person $person): array
+    {
+        $members = [];
+        $visited = [];
+        $stack = [$person];
+
+        while ([] !== $stack) {
+            $current = array_pop($stack);
+            $key = $this->getPersonKey($current);
+
+            if (isset($visited[$key])) {
+                continue;
+            }
+
+            $visited[$key] = true;
+            $members[] = $current;
+
+            $parentUnion = $current->getParentUnion();
+
+            if (null === $parentUnion) {
+                continue;
+            }
+
+            foreach ($parentUnion->getPeople() as $parent) {
+                $stack[] = $parent;
+            }
+        }
+
+        usort($members, static fn (Person $left, Person $right): int => strcmp($left->getFullName(), $right->getFullName()));
+
+        return $members;
+    }
+
+    private function getPersonKey(Person $person): string
+    {
+        return null === $person->getId() ? 'obj-'.spl_object_id($person) : 'id-'.$person->getId();
+    }
+}

--- a/src/Service/Tree/PersonAncestorBranchMemberCollector.php
+++ b/src/Service/Tree/PersonAncestorBranchMemberCollector.php
@@ -3,17 +3,31 @@
 namespace App\Service\Tree;
 
 use App\Entity\Person;
+use App\Repository\PersonRepository;
 
 class PersonAncestorBranchMemberCollector
 {
+    public function __construct(
+        private readonly PersonRepository $personRepository,
+    ) {
+    }
+
     /**
      * @return array<int, Person>
      */
     public function collect(Person $person): array
     {
+        $treeMembers = $this->personRepository->findByTreeForStatisticsGraph($person->getTree());
+        $indexedMembers = [];
+
+        foreach ($treeMembers as $member) {
+            $indexedMembers[$this->getPersonKey($member)] = $member;
+        }
+
+        $root = $indexedMembers[$this->getPersonKey($person)] ?? $person;
         $members = [];
         $visited = [];
-        $stack = [$person];
+        $stack = [$root];
 
         while ([] !== $stack) {
             $current = array_pop($stack);

--- a/src/Service/Tree/TreeStatisticsBuilder.php
+++ b/src/Service/Tree/TreeStatisticsBuilder.php
@@ -41,6 +41,37 @@ class TreeStatisticsBuilder
     {
         $members = $this->personRepository->findByTreeForStatistics($tree);
 
+        return $this->buildFromMembers($members);
+    }
+
+    /**
+     * @param array<int, Person> $members
+     *
+     * @return array{
+     *     members_count: int,
+     *     oldest_birth: ?array{person: Person, date: \DateTimeInterface},
+     *     oldest_death: ?array{person: Person, date: \DateTimeInterface},
+     *     women_age_summary: ?array{
+     *         min: array{person: Person, age: int, approximate: bool},
+     *         max: array{person: Person, age: int, approximate: bool},
+     *         average: array{age: float, approximate: bool, count: int}
+     *     },
+     *     men_age_summary: ?array{
+     *         min: array{person: Person, age: int, approximate: bool},
+     *         max: array{person: Person, age: int, approximate: bool},
+     *         average: array{age: float, approximate: bool, count: int}
+     *     },
+     *     unknown_gender_age_summary: ?array{
+     *         min: array{person: Person, age: int, approximate: bool},
+     *         max: array{person: Person, age: int, approximate: bool},
+     *         average: array{age: float, approximate: bool, count: int}
+     *     },
+     *     births_by_year: array{labels: list<string>, data: list<int>},
+     *     deaths_by_year: array{labels: list<string>, data: list<int>}
+     * }
+     */
+    public function buildFromMembers(array $members): array
+    {
         return [
             'members_count' => count($members),
             'oldest_birth' => $this->findOldestDateRecord($members, static fn (Person $person): ?\DateTimeInterface => $person->getBirth()),

--- a/src/Service/Tree/TreeStatisticsBuilder.php
+++ b/src/Service/Tree/TreeStatisticsBuilder.php
@@ -148,6 +148,8 @@ class TreeStatisticsBuilder
     private function buildYearDataset(array $members, callable $dateAccessor): array
     {
         $countsByYear = [];
+        $minYear = null;
+        $maxYear = null;
 
         foreach ($members as $member) {
             $date = $dateAccessor($member);
@@ -156,8 +158,21 @@ class TreeStatisticsBuilder
                 continue;
             }
 
-            $year = $date->format('Y');
+            $year = (int) $date->format('Y');
             $countsByYear[$year] = ($countsByYear[$year] ?? 0) + 1;
+            $minYear = null === $minYear ? $year : min($minYear, $year);
+            $maxYear = null === $maxYear ? $year : max($maxYear, $year);
+        }
+
+        if (null === $minYear || null === $maxYear) {
+            return [
+                'labels' => [],
+                'data' => [],
+            ];
+        }
+
+        for ($year = $minYear; $year <= $maxYear; ++$year) {
+            $countsByYear[$year] ??= 0;
         }
 
         ksort($countsByYear);

--- a/src/Service/Tree/TreeStatisticsBuilder.php
+++ b/src/Service/Tree/TreeStatisticsBuilder.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Service\Tree;
+
+use App\Entity\Person;
+use App\Entity\Tree;
+use App\Repository\PersonRepository;
+
+class TreeStatisticsBuilder
+{
+    public function __construct(
+        private readonly PersonRepository $personRepository,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     members_count: int,
+     *     oldest_birth: ?array{person: Person, date: \DateTimeInterface},
+     *     oldest_death: ?array{person: Person, date: \DateTimeInterface},
+     *     women_age_summary: ?array{
+     *         min: array{person: Person, age: int, approximate: bool},
+     *         max: array{person: Person, age: int, approximate: bool},
+     *         average: array{age: float, approximate: bool, count: int}
+     *     },
+     *     men_age_summary: ?array{
+     *         min: array{person: Person, age: int, approximate: bool},
+     *         max: array{person: Person, age: int, approximate: bool},
+     *         average: array{age: float, approximate: bool, count: int}
+     *     },
+     *     unknown_gender_age_summary: ?array{
+     *         min: array{person: Person, age: int, approximate: bool},
+     *         max: array{person: Person, age: int, approximate: bool},
+     *         average: array{age: float, approximate: bool, count: int}
+     *     },
+     *     births_by_year: array{labels: list<string>, data: list<int>},
+     *     deaths_by_year: array{labels: list<string>, data: list<int>}
+     * }
+     */
+    public function build(Tree $tree): array
+    {
+        $members = $this->personRepository->findByTreeForStatistics($tree);
+
+        return [
+            'members_count' => count($members),
+            'oldest_birth' => $this->findOldestDateRecord($members, static fn (Person $person): ?\DateTimeInterface => $person->getBirth()),
+            'oldest_death' => $this->findOldestDateRecord($members, static fn (Person $person): ?\DateTimeInterface => $person->getDeath()),
+            'women_age_summary' => $this->buildAgeSummary($members, static fn (Person $person): bool => Person::FEMALE === $person->getGender()),
+            'men_age_summary' => $this->buildAgeSummary($members, static fn (Person $person): bool => Person::MALE === $person->getGender()),
+            'unknown_gender_age_summary' => $this->buildAgeSummary($members, static fn (Person $person): bool => !in_array($person->getGender(), [Person::FEMALE, Person::MALE], true)),
+            'births_by_year' => $this->buildYearDataset($members, static fn (Person $person): ?\DateTimeInterface => $person->getBirth()),
+            'deaths_by_year' => $this->buildYearDataset($members, static fn (Person $person): ?\DateTimeInterface => $person->getDeath()),
+        ];
+    }
+
+    /**
+     * @param array<int, Person>                    $members
+     * @param callable(Person): ?\DateTimeInterface $dateAccessor
+     *
+     * @return ?array{person: Person, date: \DateTimeInterface}
+     */
+    private function findOldestDateRecord(array $members, callable $dateAccessor): ?array
+    {
+        $oldestRecord = null;
+
+        foreach ($members as $member) {
+            $date = $dateAccessor($member);
+
+            if (!$date instanceof \DateTimeInterface) {
+                continue;
+            }
+
+            if (null === $oldestRecord || $date < $oldestRecord['date']) {
+                $oldestRecord = [
+                    'person' => $member,
+                    'date' => $date,
+                ];
+            }
+        }
+
+        return $oldestRecord;
+    }
+
+    /**
+     * @param array<int, Person>     $members
+     * @param callable(Person): bool $filter
+     *
+     * @return ?array{
+     *     min: array{person: Person, age: int, approximate: bool},
+     *     max: array{person: Person, age: int, approximate: bool},
+     *     average: array{age: float, approximate: bool, count: int}
+     * }
+     */
+    private function buildAgeSummary(array $members, callable $filter): ?array
+    {
+        $ageRecords = [];
+
+        foreach ($members as $member) {
+            if (!$filter($member)) {
+                continue;
+            }
+
+            $age = $member->getAge();
+
+            if (null === $age) {
+                continue;
+            }
+
+            $ageRecords[] = [
+                'person' => $member,
+                'age' => $age,
+                'approximate' => $member->isAgeApproximate(),
+            ];
+        }
+
+        if ([] === $ageRecords) {
+            return null;
+        }
+
+        usort(
+            $ageRecords,
+            static fn (array $left, array $right): int => $left['age'] <=> $right['age'] ?: strcmp($left['person']->getFullName(), $right['person']->getFullName())
+        );
+
+        $ageValues = array_column($ageRecords, 'age');
+
+        return [
+            'min' => $ageRecords[0],
+            'max' => $ageRecords[array_key_last($ageRecords)],
+            'average' => [
+                'age' => round(array_sum($ageValues) / count($ageValues), 1),
+                'approximate' => array_reduce(
+                    $ageRecords,
+                    static fn (bool $carry, array $record): bool => $carry || $record['approximate'],
+                    false,
+                ),
+                'count' => count($ageRecords),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, Person>                    $members
+     * @param callable(Person): ?\DateTimeInterface $dateAccessor
+     *
+     * @return array{labels: list<string>, data: list<int>}
+     */
+    private function buildYearDataset(array $members, callable $dateAccessor): array
+    {
+        $countsByYear = [];
+
+        foreach ($members as $member) {
+            $date = $dateAccessor($member);
+
+            if (!$date instanceof \DateTimeInterface) {
+                continue;
+            }
+
+            $year = $date->format('Y');
+            $countsByYear[$year] = ($countsByYear[$year] ?? 0) + 1;
+        }
+
+        ksort($countsByYear);
+
+        return [
+            'labels' => array_map(strval(...), array_keys($countsByYear)),
+            'data' => array_values($countsByYear),
+        ];
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -315,6 +315,9 @@
             "templates/base.html.twig"
         ]
     },
+    "symfony/ux-chartjs": {
+        "version": "v3.0.0"
+    },
     "symfony/ux-turbo": {
         "version": "v2.13.2"
     },

--- a/templates/person/base.html.twig
+++ b/templates/person/base.html.twig
@@ -128,6 +128,15 @@
                                 </a>
                             </li>
                             <li class="nav-item">
+                                <a
+                                    href="{{ path('app_person_statistics', { id: person.id }) }}"
+                                    class="nav-link{{ route_name starts with 'app_person_statistics' ? ' active':'' }}"
+                                >
+                                    <i class="fa-solid fa-chart-line"></i>
+                                    {{ 'action.statistics'|trans }}
+                                </a>
+                            </li>
+                            <li class="nav-item">
                                 {% set is_active = route_name starts with 'app_source' %}
                                 <a 
                                     class="nav-link{{ is_active ? ' active':'' }}"

--- a/templates/person/statistics.html.twig
+++ b/templates/person/statistics.html.twig
@@ -31,7 +31,11 @@
                     <div class="card-body">
                         <div class="text-secondary small mb-2">{{ 'tree.statistics.oldest_birth.title'|trans }}</div>
                         {% if statistics.oldest_birth %}
-                            <div class="fw-semibold">{{ statistics.oldest_birth.person.fullName }}</div>
+                            <div class="fw-semibold">
+                                <a href="{{ path('app_person_show', { id: statistics.oldest_birth.person.id }) }}" class="link-body-emphasis text-decoration-none link-underline-opacity-0 link-underline-opacity-100-hover">
+                                    {{ statistics.oldest_birth.person.fullName }}
+                                </a>
+                            </div>
                             <div>{{ statistics.oldest_birth.date|date('d/m/Y') }}</div>
                         {% else %}
                             <div class="text-secondary">{{ 'tree.statistics.no_oldest_birth'|trans }}</div>
@@ -44,7 +48,11 @@
                     <div class="card-body">
                         <div class="text-secondary small mb-2">{{ 'tree.statistics.oldest_death.title'|trans }}</div>
                         {% if statistics.oldest_death %}
-                            <div class="fw-semibold">{{ statistics.oldest_death.person.fullName }}</div>
+                            <div class="fw-semibold">
+                                <a href="{{ path('app_person_show', { id: statistics.oldest_death.person.id }) }}" class="link-body-emphasis text-decoration-none link-underline-opacity-0 link-underline-opacity-100-hover">
+                                    {{ statistics.oldest_death.person.fullName }}
+                                </a>
+                            </div>
                             <div>{{ statistics.oldest_death.date|date('d/m/Y') }}</div>
                         {% else %}
                             <div class="text-secondary">{{ 'tree.statistics.no_oldest_death'|trans }}</div>
@@ -79,14 +87,22 @@
                                         <div class="fw-semibold">
                                             {{ summary.data.min.approximate ? '~' : '' }}{{ summary.data.min.age }}
                                         </div>
-                                        <div class="small">{{ summary.data.min.person.fullName }}</div>
+                                        <div class="small">
+                                            <a href="{{ path('app_person_show', { id: summary.data.min.person.id }) }}" class="link-body-emphasis text-decoration-none link-underline-opacity-0 link-underline-opacity-100-hover">
+                                                {{ summary.data.min.person.fullName }}
+                                            </a>
+                                        </div>
                                     </div>
                                     <div class="col-6">
                                         <div class="text-secondary small">{{ 'tree.statistics.max_age'|trans }}</div>
                                         <div class="fw-semibold">
                                             {{ summary.data.max.approximate ? '~' : '' }}{{ summary.data.max.age }}
                                         </div>
-                                        <div class="small">{{ summary.data.max.person.fullName }}</div>
+                                        <div class="small">
+                                            <a href="{{ path('app_person_show', { id: summary.data.max.person.id }) }}" class="link-body-emphasis text-decoration-none link-underline-opacity-0 link-underline-opacity-100-hover">
+                                                {{ summary.data.max.person.fullName }}
+                                            </a>
+                                        </div>
                                     </div>
                                 </div>
 

--- a/templates/person/statistics.html.twig
+++ b/templates/person/statistics.html.twig
@@ -1,0 +1,163 @@
+{% extends 'person/base.html.twig' %}
+
+{% block title %}{{ 'title.person_statistics'|trans({ name: person.fullName }) }}{% endblock %}
+
+{% block breadcrumb %}
+    {{ include('_includes/main/breadcrumb.html.twig', { items: [
+        { label: person.tree.name, link: path('app_tree_show', { id: person.tree.id }) },
+        { label: person.fullName, link: path('app_person_show', { id: person.id }) },
+        { label: 'action.statistics'|trans, link: null },
+    ] }) }}
+{% endblock %}
+
+{% block content %}
+    <section class="mb-4">
+        <div class="mb-4">
+            <h2 class="h3 mb-1">{{ 'title.person_statistics'|trans({ name: person.fullName }) }}</h2>
+            <p class="text-secondary mb-0">{{ 'person.statistics.description'|trans }}</p>
+        </div>
+
+        <div class="row g-3 mb-4">
+            <div class="col-md-4">
+                <div class="card h-100 shadow-sm border-0">
+                    <div class="card-body">
+                        <div class="text-secondary small mb-2">{{ 'tree.statistics.members_count'|trans }}</div>
+                        <div class="display-6 mb-0">{{ statistics.members_count }}</div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="card h-100 shadow-sm border-0">
+                    <div class="card-body">
+                        <div class="text-secondary small mb-2">{{ 'tree.statistics.oldest_birth.title'|trans }}</div>
+                        {% if statistics.oldest_birth %}
+                            <div class="fw-semibold">{{ statistics.oldest_birth.person.fullName }}</div>
+                            <div>{{ statistics.oldest_birth.date|date('d/m/Y') }}</div>
+                        {% else %}
+                            <div class="text-secondary">{{ 'tree.statistics.no_oldest_birth'|trans }}</div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="card h-100 shadow-sm border-0">
+                    <div class="card-body">
+                        <div class="text-secondary small mb-2">{{ 'tree.statistics.oldest_death.title'|trans }}</div>
+                        {% if statistics.oldest_death %}
+                            <div class="fw-semibold">{{ statistics.oldest_death.person.fullName }}</div>
+                            <div>{{ statistics.oldest_death.date|date('d/m/Y') }}</div>
+                        {% else %}
+                            <div class="text-secondary">{{ 'tree.statistics.no_oldest_death'|trans }}</div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row g-3 mb-4">
+            {% for summary in [
+                { key: 'women', title: 'tree.statistics.summary.women'|trans, data: statistics.women_age_summary },
+                { key: 'men', title: 'tree.statistics.summary.men'|trans, data: statistics.men_age_summary },
+                { key: 'unknown', title: 'tree.statistics.summary.unknown'|trans, data: statistics.unknown_gender_age_summary },
+            ] %}
+                {% if summary.data %}
+                    <div class="col-lg-4">
+                        <div class="card h-100 shadow-sm border-0">
+                            <div class="card-body">
+                                <h2 class="h5 mb-3">{{ summary.title }}</h2>
+
+                                <div class="mb-3">
+                                    <div class="text-secondary small">{{ 'tree.statistics.average_age'|trans }}</div>
+                                    <div class="fs-4 fw-semibold">
+                                        {{ summary.data.average.approximate ? '~' : '' }}{{ summary.data.average.age|number_format(1, '.', '') }}
+                                    </div>
+                                </div>
+
+                                <div class="row g-3">
+                                    <div class="col-6">
+                                        <div class="text-secondary small">{{ 'tree.statistics.min_age'|trans }}</div>
+                                        <div class="fw-semibold">
+                                            {{ summary.data.min.approximate ? '~' : '' }}{{ summary.data.min.age }}
+                                        </div>
+                                        <div class="small">{{ summary.data.min.person.fullName }}</div>
+                                    </div>
+                                    <div class="col-6">
+                                        <div class="text-secondary small">{{ 'tree.statistics.max_age'|trans }}</div>
+                                        <div class="fw-semibold">
+                                            {{ summary.data.max.approximate ? '~' : '' }}{{ summary.data.max.age }}
+                                        </div>
+                                        <div class="small">{{ summary.data.max.person.fullName }}</div>
+                                    </div>
+                                </div>
+
+                                <div class="text-secondary small mt-3">
+                                    {{ 'tree.statistics.people_used_count'|trans({ count: summary.data.average.count }) }}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
+            {% endfor %}
+        </div>
+
+        <div data-controller="chart-mode">
+            <div class="form-check form-switch mb-3">
+                <input
+                    id="chart-mode-toggle"
+                    class="form-check-input"
+                    type="checkbox"
+                    role="switch"
+                    data-chart-mode-target="toggle"
+                    data-action="chart-mode#update"
+                >
+                <label class="form-check-label" for="chart-mode-toggle">
+                    {{ 'tree.statistics.extended_chart_mode'|trans }}
+                </label>
+            </div>
+
+            <div class="row g-4">
+                <div class="col-12">
+                    <div class="card shadow-sm border-0">
+                        <div class="card-body">
+                            <h2 class="h4 mb-3">{{ 'tree.statistics.births.title'|trans }}</h2>
+                            {% if births_chart %}
+                                <div data-chart-mode-target="scrollArea">
+                                    <div
+                                        data-chart-mode-target="chart"
+                                        data-years="{{ statistics.births_by_year.labels|length }}"
+                                        style="height: 320px; min-width: 100%;"
+                                    >
+                                        {{ render_chart(births_chart, { class: 'w-100 h-100' }) }}
+                                    </div>
+                                </div>
+                            {% else %}
+                                <p class="text-secondary mb-0">{{ 'tree.statistics.no_birth_data'|trans }}</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-12">
+                    <div class="card shadow-sm border-0">
+                        <div class="card-body">
+                            <h2 class="h4 mb-3">{{ 'tree.statistics.deaths.title'|trans }}</h2>
+                            {% if deaths_chart %}
+                                <div data-chart-mode-target="scrollArea">
+                                    <div
+                                        data-chart-mode-target="chart"
+                                        data-years="{{ statistics.deaths_by_year.labels|length }}"
+                                        style="height: 320px; min-width: 100%;"
+                                    >
+                                        {{ render_chart(deaths_chart, { class: 'w-100 h-100' }) }}
+                                    </div>
+                                </div>
+                            {% else %}
+                                <p class="text-secondary mb-0">{{ 'tree.statistics.no_death_data'|trans }}</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/templates/tree/show.html.twig
+++ b/templates/tree/show.html.twig
@@ -28,6 +28,10 @@
                         <i class="fa-solid fa-fw fa-plus"></i>
                         {{ 'action.new_member'|trans }}
                     </a>
+                    <a href="{{ path('app_tree_statistics', { id: tree.id }) }}" class="list-group-item link-primary">
+                        <i class="fa-solid fa-fw fa-chart-line"></i>
+                        {{ 'action.statistics'|trans }}
+                    </a>
                 </div>
 
                 {% if favorites|length %}

--- a/templates/tree/statistics.html.twig
+++ b/templates/tree/statistics.html.twig
@@ -1,0 +1,136 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ 'title.tree_statistics'|trans({ name: tree.name }) }}{% endblock %}
+
+{% block body %}
+    {{ include('_includes/main/breadcrumb.html.twig', { items: [
+        { label: tree.name, link: path('app_tree_show', { id: tree.id }) },
+        { label: 'action.statistics'|trans, link: null },
+    ] }) }}
+
+    <section class="my-4">
+        <div class="container">
+            <div class="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-4">
+                <div>
+                    <h1 class="h2 mb-1">{{ 'title.tree_statistics'|trans({ name: tree.name }) }}</h1>
+                    <p class="text-secondary mb-0">{{ 'tree.statistics.description'|trans }}</p>
+                </div>
+                <a href="{{ path('app_tree_show', { id: tree.id }) }}" class="btn btn-outline-secondary">
+                    <i class="fa-solid fa-arrow-left"></i>
+                    {{ 'action.show_tree_members'|trans }}
+                </a>
+            </div>
+
+            <div class="row g-3 mb-4">
+                <div class="col-md-4">
+                    <div class="card h-100 shadow-sm border-0">
+                        <div class="card-body">
+                            <div class="text-secondary small mb-2">{{ 'tree.statistics.members_count'|trans }}</div>
+                            <div class="display-6 mb-0">{{ statistics.members_count }}</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="card h-100 shadow-sm border-0">
+                        <div class="card-body">
+                            <div class="text-secondary small mb-2">{{ 'tree.statistics.oldest_birth.title'|trans }}</div>
+                            {% if statistics.oldest_birth %}
+                                <div class="fw-semibold">{{ statistics.oldest_birth.person.fullName }}</div>
+                                <div>{{ statistics.oldest_birth.date|date('d/m/Y') }}</div>
+                            {% else %}
+                                <div class="text-secondary">{{ 'tree.statistics.no_oldest_birth'|trans }}</div>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="card h-100 shadow-sm border-0">
+                        <div class="card-body">
+                            <div class="text-secondary small mb-2">{{ 'tree.statistics.oldest_death.title'|trans }}</div>
+                            {% if statistics.oldest_death %}
+                                <div class="fw-semibold">{{ statistics.oldest_death.person.fullName }}</div>
+                                <div>{{ statistics.oldest_death.date|date('d/m/Y') }}</div>
+                            {% else %}
+                                <div class="text-secondary">{{ 'tree.statistics.no_oldest_death'|trans }}</div>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row g-3 mb-4">
+                {% for summary in [
+                    { key: 'women', title: 'tree.statistics.summary.women'|trans, data: statistics.women_age_summary },
+                    { key: 'men', title: 'tree.statistics.summary.men'|trans, data: statistics.men_age_summary },
+                    { key: 'unknown', title: 'tree.statistics.summary.unknown'|trans, data: statistics.unknown_gender_age_summary },
+                ] %}
+                    {% if summary.data %}
+                        <div class="col-lg-4">
+                            <div class="card h-100 shadow-sm border-0">
+                                <div class="card-body">
+                                    <h2 class="h5 mb-3">{{ summary.title }}</h2>
+
+                                    <div class="mb-3">
+                                        <div class="text-secondary small">{{ 'tree.statistics.average_age'|trans }}</div>
+                                        <div class="fs-4 fw-semibold">
+                                            {{ summary.data.average.approximate ? '~' : '' }}{{ summary.data.average.age|number_format(1, '.', '') }}
+                                        </div>
+                                    </div>
+
+                                    <div class="row g-3">
+                                        <div class="col-6">
+                                            <div class="text-secondary small">{{ 'tree.statistics.min_age'|trans }}</div>
+                                            <div class="fw-semibold">
+                                                {{ summary.data.min.approximate ? '~' : '' }}{{ summary.data.min.age }}
+                                            </div>
+                                            <div class="small">{{ summary.data.min.person.fullName }}</div>
+                                        </div>
+                                        <div class="col-6">
+                                            <div class="text-secondary small">{{ 'tree.statistics.max_age'|trans }}</div>
+                                            <div class="fw-semibold">
+                                                {{ summary.data.max.approximate ? '~' : '' }}{{ summary.data.max.age }}
+                                            </div>
+                                            <div class="small">{{ summary.data.max.person.fullName }}</div>
+                                        </div>
+                                    </div>
+
+                                    <div class="text-secondary small mt-3">
+                                        {{ 'tree.statistics.people_used_count'|trans({ count: summary.data.average.count }) }}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% endif %}
+                {% endfor %}
+            </div>
+
+            <div class="row g-4">
+                <div class="col-12">
+                    <div class="card shadow-sm border-0">
+                        <div class="card-body">
+                            <h2 class="h4 mb-3">{{ 'tree.statistics.births.title'|trans }}</h2>
+                            {% if births_chart %}
+                                {{ render_chart(births_chart, { class: 'w-100', style: 'height: 320px;' }) }}
+                            {% else %}
+                                <p class="text-secondary mb-0">{{ 'tree.statistics.no_birth_data'|trans }}</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-12">
+                    <div class="card shadow-sm border-0">
+                        <div class="card-body">
+                            <h2 class="h4 mb-3">{{ 'tree.statistics.deaths.title'|trans }}</h2>
+                            {% if deaths_chart %}
+                                {{ render_chart(deaths_chart, { class: 'w-100', style: 'height: 320px;' }) }}
+                            {% else %}
+                                <p class="text-secondary mb-0">{{ 'tree.statistics.no_death_data'|trans }}</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/templates/tree/statistics.html.twig
+++ b/templates/tree/statistics.html.twig
@@ -31,7 +31,11 @@
                         <div class="card-body">
                             <div class="text-secondary small mb-2">{{ 'tree.statistics.oldest_birth.title'|trans }}</div>
                             {% if statistics.oldest_birth %}
-                                <div class="fw-semibold">{{ statistics.oldest_birth.person.fullName }}</div>
+                                <div class="fw-semibold">
+                                    <a href="{{ path('app_person_show', { id: statistics.oldest_birth.person.id }) }}" class="link-body-emphasis text-decoration-none link-underline-opacity-0 link-underline-opacity-100-hover">
+                                        {{ statistics.oldest_birth.person.fullName }}
+                                    </a>
+                                </div>
                                 <div>{{ statistics.oldest_birth.date|date('d/m/Y') }}</div>
                             {% else %}
                                 <div class="text-secondary">{{ 'tree.statistics.no_oldest_birth'|trans }}</div>
@@ -44,7 +48,11 @@
                         <div class="card-body">
                             <div class="text-secondary small mb-2">{{ 'tree.statistics.oldest_death.title'|trans }}</div>
                             {% if statistics.oldest_death %}
-                                <div class="fw-semibold">{{ statistics.oldest_death.person.fullName }}</div>
+                                <div class="fw-semibold">
+                                    <a href="{{ path('app_person_show', { id: statistics.oldest_death.person.id }) }}" class="link-body-emphasis text-decoration-none link-underline-opacity-0 link-underline-opacity-100-hover">
+                                        {{ statistics.oldest_death.person.fullName }}
+                                    </a>
+                                </div>
                                 <div>{{ statistics.oldest_death.date|date('d/m/Y') }}</div>
                             {% else %}
                                 <div class="text-secondary">{{ 'tree.statistics.no_oldest_death'|trans }}</div>
@@ -79,14 +87,22 @@
                                             <div class="fw-semibold">
                                                 {{ summary.data.min.approximate ? '~' : '' }}{{ summary.data.min.age }}
                                             </div>
-                                            <div class="small">{{ summary.data.min.person.fullName }}</div>
+                                            <div class="small">
+                                                <a href="{{ path('app_person_show', { id: summary.data.min.person.id }) }}" class="link-body-emphasis text-decoration-none link-underline-opacity-0 link-underline-opacity-100-hover">
+                                                    {{ summary.data.min.person.fullName }}
+                                                </a>
+                                            </div>
                                         </div>
                                         <div class="col-6">
                                             <div class="text-secondary small">{{ 'tree.statistics.max_age'|trans }}</div>
                                             <div class="fw-semibold">
                                                 {{ summary.data.max.approximate ? '~' : '' }}{{ summary.data.max.age }}
                                             </div>
-                                            <div class="small">{{ summary.data.max.person.fullName }}</div>
+                                            <div class="small">
+                                                <a href="{{ path('app_person_show', { id: summary.data.max.person.id }) }}" class="link-body-emphasis text-decoration-none link-underline-opacity-0 link-underline-opacity-100-hover">
+                                                    {{ summary.data.max.person.fullName }}
+                                                </a>
+                                            </div>
                                         </div>
                                     </div>
 

--- a/templates/tree/statistics.html.twig
+++ b/templates/tree/statistics.html.twig
@@ -104,14 +104,33 @@
                 {% endfor %}
             </div>
 
-            <div class="row g-4">
+            <div data-controller="chart-mode">
+                <div class="form-check form-switch mb-3">
+                    <input
+                        id="chart-mode-toggle"
+                        class="form-check-input"
+                        type="checkbox"
+                        role="switch"
+                        data-chart-mode-target="toggle"
+                        data-action="chart-mode#update"
+                    >
+                    <label class="form-check-label" for="chart-mode-toggle">
+                        {{ 'tree.statistics.extended_chart_mode'|trans }}
+                    </label>
+                </div>
+
+                <div class="row g-4">
                 <div class="col-12">
                     <div class="card shadow-sm border-0">
                         <div class="card-body">
                             <h2 class="h4 mb-3">{{ 'tree.statistics.births.title'|trans }}</h2>
                             {% if births_chart %}
-                                <div class="overflow-x-auto">
-                                    <div style="height: 320px; min-width: max(100%, {{ statistics.births_by_year.labels|length }}em);">
+                                <div data-chart-mode-target="scrollArea">
+                                    <div
+                                        data-chart-mode-target="chart"
+                                        data-years="{{ statistics.births_by_year.labels|length }}"
+                                        style="height: 320px; min-width: 100%;"
+                                    >
                                         {{ render_chart(births_chart, { class: 'w-100 h-100' }) }}
                                     </div>
                                 </div>
@@ -127,8 +146,12 @@
                         <div class="card-body">
                             <h2 class="h4 mb-3">{{ 'tree.statistics.deaths.title'|trans }}</h2>
                             {% if deaths_chart %}
-                                <div class="overflow-x-auto">
-                                    <div style="height: 320px; min-width: max(100%, {{ statistics.deaths_by_year.labels|length }}em);">
+                                <div data-chart-mode-target="scrollArea">
+                                    <div
+                                        data-chart-mode-target="chart"
+                                        data-years="{{ statistics.deaths_by_year.labels|length }}"
+                                        style="height: 320px; min-width: 100%;"
+                                    >
                                         {{ render_chart(deaths_chart, { class: 'w-100 h-100' }) }}
                                     </div>
                                 </div>
@@ -138,6 +161,7 @@
                         </div>
                     </div>
                 </div>
+            </div>
             </div>
         </div>
     </section>

--- a/templates/tree/statistics.html.twig
+++ b/templates/tree/statistics.html.twig
@@ -15,10 +15,6 @@
                     <h1 class="h2 mb-1">{{ 'title.tree_statistics'|trans({ name: tree.name }) }}</h1>
                     <p class="text-secondary mb-0">{{ 'tree.statistics.description'|trans }}</p>
                 </div>
-                <a href="{{ path('app_tree_show', { id: tree.id }) }}" class="btn btn-outline-secondary">
-                    <i class="fa-solid fa-arrow-left"></i>
-                    {{ 'action.show_tree_members'|trans }}
-                </a>
             </div>
 
             <div class="row g-3 mb-4">

--- a/templates/tree/statistics.html.twig
+++ b/templates/tree/statistics.html.twig
@@ -110,7 +110,9 @@
                         <div class="card-body">
                             <h2 class="h4 mb-3">{{ 'tree.statistics.births.title'|trans }}</h2>
                             {% if births_chart %}
-                                {{ render_chart(births_chart, { class: 'w-100', style: 'height: 320px;' }) }}
+                                <div style="height: 320px;">
+                                    {{ render_chart(births_chart, { class: 'w-100 h-100' }) }}
+                                </div>
                             {% else %}
                                 <p class="text-secondary mb-0">{{ 'tree.statistics.no_birth_data'|trans }}</p>
                             {% endif %}
@@ -123,7 +125,9 @@
                         <div class="card-body">
                             <h2 class="h4 mb-3">{{ 'tree.statistics.deaths.title'|trans }}</h2>
                             {% if deaths_chart %}
-                                {{ render_chart(deaths_chart, { class: 'w-100', style: 'height: 320px;' }) }}
+                                <div style="height: 320px;">
+                                    {{ render_chart(deaths_chart, { class: 'w-100 h-100' }) }}
+                                </div>
                             {% else %}
                                 <p class="text-secondary mb-0">{{ 'tree.statistics.no_death_data'|trans }}</p>
                             {% endif %}

--- a/templates/tree/statistics.html.twig
+++ b/templates/tree/statistics.html.twig
@@ -110,8 +110,10 @@
                         <div class="card-body">
                             <h2 class="h4 mb-3">{{ 'tree.statistics.births.title'|trans }}</h2>
                             {% if births_chart %}
-                                <div style="height: 320px;">
-                                    {{ render_chart(births_chart, { class: 'w-100 h-100' }) }}
+                                <div class="overflow-x-auto">
+                                    <div style="height: 320px; min-width: max(100%, {{ statistics.births_by_year.labels|length }}em);">
+                                        {{ render_chart(births_chart, { class: 'w-100 h-100' }) }}
+                                    </div>
                                 </div>
                             {% else %}
                                 <p class="text-secondary mb-0">{{ 'tree.statistics.no_birth_data'|trans }}</p>
@@ -125,8 +127,10 @@
                         <div class="card-body">
                             <h2 class="h4 mb-3">{{ 'tree.statistics.deaths.title'|trans }}</h2>
                             {% if deaths_chart %}
-                                <div style="height: 320px;">
-                                    {{ render_chart(deaths_chart, { class: 'w-100 h-100' }) }}
+                                <div class="overflow-x-auto">
+                                    <div style="height: 320px; min-width: max(100%, {{ statistics.deaths_by_year.labels|length }}em);">
+                                        {{ render_chart(deaths_chart, { class: 'w-100 h-100' }) }}
+                                    </div>
                                 </div>
                             {% else %}
                                 <p class="text-secondary mb-0">{{ 'tree.statistics.no_death_data'|trans }}</p>

--- a/tests/Service/Tree/PersonAncestorBranchMemberCollectorTest.php
+++ b/tests/Service/Tree/PersonAncestorBranchMemberCollectorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service\Tree;
+
+use App\Entity\Person;
+use App\Entity\Union;
+use App\Service\Tree\PersonAncestorBranchMemberCollector;
+use PHPUnit\Framework\TestCase;
+
+final class PersonAncestorBranchMemberCollectorTest extends TestCase
+{
+    public function testItCollectsSelectedPersonAndUniqueAncestors(): void
+    {
+        $root = $this->createPerson('Root', 'Person');
+        $mother = $this->createPerson('Mother', 'Parent');
+        $father = $this->createPerson('Father', 'Parent');
+        $grandMother = $this->createPerson('Grand', 'Mother');
+        $sharedAncestor = $this->createPerson('Shared', 'Ancestor');
+
+        $rootParents = (new Union())
+            ->addPerson($mother)
+            ->addPerson($father)
+        ;
+        $root->setParentUnion($rootParents);
+
+        $motherParents = (new Union())
+            ->addPerson($grandMother)
+            ->addPerson($sharedAncestor)
+        ;
+        $mother->setParentUnion($motherParents);
+
+        $fatherParents = (new Union())
+            ->addPerson($sharedAncestor)
+        ;
+        $father->setParentUnion($fatherParents);
+
+        $members = (new PersonAncestorBranchMemberCollector())->collect($root);
+
+        self::assertSame([
+            'ANCESTOR Shared',
+            'MOTHER Grand',
+            'PARENT Father',
+            'PARENT Mother',
+            'PERSON Root',
+        ], array_map(static fn (Person $person): string => $person->getFullName(), $members));
+    }
+
+    private function createPerson(string $firstname, string $lastname): Person
+    {
+        return (new Person())
+            ->setFirstname($firstname)
+            ->setLastname($lastname)
+        ;
+    }
+}

--- a/tests/Service/Tree/PersonAncestorBranchMemberCollectorTest.php
+++ b/tests/Service/Tree/PersonAncestorBranchMemberCollectorTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Tests\Service\Tree;
 
 use App\Entity\Person;
+use App\Entity\Tree;
 use App\Entity\Union;
+use App\Repository\PersonRepository;
 use App\Service\Tree\PersonAncestorBranchMemberCollector;
 use PHPUnit\Framework\TestCase;
 
@@ -13,11 +15,12 @@ final class PersonAncestorBranchMemberCollectorTest extends TestCase
 {
     public function testItCollectsSelectedPersonAndUniqueAncestors(): void
     {
-        $root = $this->createPerson('Root', 'Person');
-        $mother = $this->createPerson('Mother', 'Parent');
-        $father = $this->createPerson('Father', 'Parent');
-        $grandMother = $this->createPerson('Grand', 'Mother');
-        $sharedAncestor = $this->createPerson('Shared', 'Ancestor');
+        $tree = new Tree();
+        $root = $this->createPerson($tree, 'Root', 'Person');
+        $mother = $this->createPerson($tree, 'Mother', 'Parent');
+        $father = $this->createPerson($tree, 'Father', 'Parent');
+        $grandMother = $this->createPerson($tree, 'Grand', 'Mother');
+        $sharedAncestor = $this->createPerson($tree, 'Shared', 'Ancestor');
 
         $rootParents = (new Union())
             ->addPerson($mother)
@@ -36,7 +39,15 @@ final class PersonAncestorBranchMemberCollectorTest extends TestCase
         ;
         $father->setParentUnion($fatherParents);
 
-        $members = (new PersonAncestorBranchMemberCollector())->collect($root);
+        $repository = $this->createMock(PersonRepository::class);
+        $repository
+            ->expects(self::once())
+            ->method('findByTreeForStatisticsGraph')
+            ->with($root->getTree())
+            ->willReturn([$root, $mother, $father, $grandMother, $sharedAncestor])
+        ;
+
+        $members = (new PersonAncestorBranchMemberCollector($repository))->collect($root);
 
         self::assertSame([
             'ANCESTOR Shared',
@@ -47,11 +58,12 @@ final class PersonAncestorBranchMemberCollectorTest extends TestCase
         ], array_map(static fn (Person $person): string => $person->getFullName(), $members));
     }
 
-    private function createPerson(string $firstname, string $lastname): Person
+    private function createPerson(Tree $tree, string $firstname, string $lastname): Person
     {
         return (new Person())
             ->setFirstname($firstname)
             ->setLastname($lastname)
+            ->setTree($tree)
         ;
     }
 }

--- a/tests/Service/Tree/TreeStatisticsBuilderTest.php
+++ b/tests/Service/Tree/TreeStatisticsBuilderTest.php
@@ -95,6 +95,25 @@ final class TreeStatisticsBuilderTest extends TestCase
         self::assertSame([], $statistics['deaths_by_year']['labels']);
     }
 
+    public function testItBuildsStatisticsFromAnExplicitMemberSubset(): void
+    {
+        $root = $this->createPerson('Root', 'Selected', Person::MALE, '1950-01-01', null, false);
+        $ancestor = $this->createPerson('Older', 'Ancestor', Person::FEMALE, '1900-01-01', '1980-01-01', true);
+        $excluded = $this->createPerson('Hidden', 'Branch', Person::FEMALE, '1800-01-01', '1870-01-01', true);
+
+        $builder = new TreeStatisticsBuilder($this->createMock(PersonRepository::class));
+        $statistics = $builder->buildFromMembers([$root, $ancestor]);
+
+        self::assertSame(2, $statistics['members_count']);
+        self::assertSame('ANCESTOR Older', $statistics['oldest_birth']['person']->getFullName());
+        self::assertSame('1980-01-01', $statistics['oldest_death']['date']->format('Y-m-d'));
+        self::assertNotSame('BRANCH Hidden', $statistics['oldest_birth']['person']->getFullName());
+        self::assertSame(['1900', '1901', '1902'], array_slice($statistics['births_by_year']['labels'], 0, 3));
+        self::assertSame('1950', $statistics['births_by_year']['labels'][array_key_last($statistics['births_by_year']['labels'])]);
+        self::assertSame(1, $statistics['births_by_year']['data'][0]);
+        self::assertSame(0, $statistics['births_by_year']['data'][1]);
+    }
+
     /**
      * @param array<int, Person> $members
      */

--- a/tests/Service/Tree/TreeStatisticsBuilderTest.php
+++ b/tests/Service/Tree/TreeStatisticsBuilderTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service\Tree;
+
+use App\Entity\Person;
+use App\Entity\Tree;
+use App\Repository\PersonRepository;
+use App\Service\Tree\TreeStatisticsBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class TreeStatisticsBuilderTest extends TestCase
+{
+    public function testItBuildsGenderSummariesAndYearlyCharts(): void
+    {
+        $tree = new Tree();
+        $members = [
+            $this->createPerson('Ada', 'Alpha', Person::FEMALE, '1900-01-01', '1970-01-01', true),
+            $this->createPerson('Beth', 'Beta', Person::FEMALE, '1910-01-01', null, false),
+            $this->createPerson('Carl', 'Gamma', Person::MALE, '1890-05-04', '1950-02-01', true),
+            $this->createPerson('Dylan', 'Delta', Person::MALE, '1925-06-01', null, false, true),
+            $this->createPerson('Evan', 'Epsilon', Person::OTHER, '1930-01-01', '2000-01-01', true),
+        ];
+
+        $builder = new TreeStatisticsBuilder($this->createRepositoryStub($tree, $members));
+        $statistics = $builder->build($tree);
+
+        self::assertSame(5, $statistics['members_count']);
+        self::assertSame('GAMMA Carl', $statistics['oldest_birth']['person']->getFullName());
+        self::assertSame('1950-02-01', $statistics['oldest_death']['date']->format('Y-m-d'));
+
+        self::assertNotNull($statistics['women_age_summary']);
+        self::assertSame('ALPHA Ada', $statistics['women_age_summary']['min']['person']->getFullName());
+        self::assertSame(70, $statistics['women_age_summary']['min']['age']);
+        self::assertSame('BETA Beth', $statistics['women_age_summary']['max']['person']->getFullName());
+        self::assertSame(2, $statistics['women_age_summary']['average']['count']);
+
+        self::assertNotNull($statistics['men_age_summary']);
+        self::assertSame('GAMMA Carl', $statistics['men_age_summary']['min']['person']->getFullName());
+        self::assertSame('DELTA Dylan', $statistics['men_age_summary']['max']['person']->getFullName());
+        self::assertTrue($statistics['men_age_summary']['max']['approximate']);
+        self::assertTrue($statistics['men_age_summary']['average']['approximate']);
+
+        self::assertNotNull($statistics['unknown_gender_age_summary']);
+        self::assertSame('EPSILON Evan', $statistics['unknown_gender_age_summary']['min']['person']->getFullName());
+
+        self::assertSame(['1890', '1900', '1910', '1925', '1930'], $statistics['births_by_year']['labels']);
+        self::assertSame([1, 1, 1, 1, 1], $statistics['births_by_year']['data']);
+        self::assertSame(['1950', '1970', '2000'], $statistics['deaths_by_year']['labels']);
+        self::assertSame([1, 1, 1], $statistics['deaths_by_year']['data']);
+    }
+
+    public function testItHidesUnknownGenderSummaryWhenNoUsableUnknownAgeExists(): void
+    {
+        $tree = new Tree();
+        $members = [
+            $this->createPerson('Ada', 'Alpha', Person::FEMALE, '1900-01-01', '1970-01-01', true),
+            $this->createPerson('Noel', 'Unknown', Person::OTHER, null, null, false),
+        ];
+
+        $builder = new TreeStatisticsBuilder($this->createRepositoryStub($tree, $members));
+        $statistics = $builder->build($tree);
+
+        self::assertNull($statistics['unknown_gender_age_summary']);
+    }
+
+    public function testItReturnsEmptyDateDatasetsWhenNoDatesAreAvailable(): void
+    {
+        $tree = new Tree();
+        $members = [
+            $this->createPerson('Noel', 'Unknown', Person::OTHER, null, null, false),
+        ];
+
+        $builder = new TreeStatisticsBuilder($this->createRepositoryStub($tree, $members));
+        $statistics = $builder->build($tree);
+
+        self::assertNull($statistics['oldest_birth']);
+        self::assertNull($statistics['oldest_death']);
+        self::assertSame([], $statistics['births_by_year']['labels']);
+        self::assertSame([], $statistics['deaths_by_year']['labels']);
+    }
+
+    /**
+     * @param array<int, Person> $members
+     */
+    private function createRepositoryStub(Tree $tree, array $members): PersonRepository
+    {
+        $repository = $this->createMock(PersonRepository::class);
+        $repository
+            ->expects(self::once())
+            ->method('findByTreeForStatistics')
+            ->with($tree)
+            ->willReturn($members)
+        ;
+
+        return $repository;
+    }
+
+    private function createPerson(
+        string $firstname,
+        string $lastname,
+        ?int $gender,
+        ?string $birth,
+        ?string $death,
+        bool $dead,
+        bool $approximateBirth = false,
+    ): Person {
+        $person = (new Person())
+            ->setFirstname($firstname)
+            ->setLastname($lastname)
+            ->setGender($gender)
+            ->setDead($dead)
+        ;
+
+        if (null !== $birth) {
+            $person->setBirth(new \DateTimeImmutable($birth));
+        }
+
+        if (null !== $death) {
+            $person->setDeath(new \DateTimeImmutable($death));
+        }
+
+        if ($approximateBirth) {
+            $person->setBirthYearUnsure(true);
+        }
+
+        return $person;
+    }
+}

--- a/tests/Service/Tree/TreeStatisticsBuilderTest.php
+++ b/tests/Service/Tree/TreeStatisticsBuilderTest.php
@@ -45,10 +45,24 @@ final class TreeStatisticsBuilderTest extends TestCase
         self::assertNotNull($statistics['unknown_gender_age_summary']);
         self::assertSame('EPSILON Evan', $statistics['unknown_gender_age_summary']['min']['person']->getFullName());
 
-        self::assertSame(['1890', '1900', '1910', '1925', '1930'], $statistics['births_by_year']['labels']);
-        self::assertSame([1, 1, 1, 1, 1], $statistics['births_by_year']['data']);
-        self::assertSame(['1950', '1970', '2000'], $statistics['deaths_by_year']['labels']);
-        self::assertSame([1, 1, 1], $statistics['deaths_by_year']['data']);
+        self::assertSame('1890', $statistics['births_by_year']['labels'][0]);
+        self::assertSame('1930', $statistics['births_by_year']['labels'][array_key_last($statistics['births_by_year']['labels'])]);
+        self::assertCount(41, $statistics['births_by_year']['labels']);
+        self::assertSame(1, $statistics['births_by_year']['data'][0]);
+        self::assertSame(0, $statistics['births_by_year']['data'][1]);
+        self::assertSame(1, $statistics['births_by_year']['data'][10]);
+        self::assertSame(0, $statistics['births_by_year']['data'][11]);
+        self::assertSame(1, $statistics['births_by_year']['data'][35]);
+        self::assertSame(1, $statistics['births_by_year']['data'][40]);
+
+        self::assertSame('1950', $statistics['deaths_by_year']['labels'][0]);
+        self::assertSame('2000', $statistics['deaths_by_year']['labels'][array_key_last($statistics['deaths_by_year']['labels'])]);
+        self::assertCount(51, $statistics['deaths_by_year']['labels']);
+        self::assertSame(1, $statistics['deaths_by_year']['data'][0]);
+        self::assertSame(0, $statistics['deaths_by_year']['data'][1]);
+        self::assertSame(1, $statistics['deaths_by_year']['data'][20]);
+        self::assertSame(0, $statistics['deaths_by_year']['data'][21]);
+        self::assertSame(1, $statistics['deaths_by_year']['data'][50]);
     }
 
     public function testItHidesUnknownGenderSummaryWhenNoUsableUnknownAgeExists(): void

--- a/tests/Service/Tree/TreeStatisticsBuilderTest.php
+++ b/tests/Service/Tree/TreeStatisticsBuilderTest.php
@@ -101,7 +101,7 @@ final class TreeStatisticsBuilderTest extends TestCase
         $ancestor = $this->createPerson('Older', 'Ancestor', Person::FEMALE, '1900-01-01', '1980-01-01', true);
         $excluded = $this->createPerson('Hidden', 'Branch', Person::FEMALE, '1800-01-01', '1870-01-01', true);
 
-        $builder = new TreeStatisticsBuilder($this->createMock(PersonRepository::class));
+        $builder = new TreeStatisticsBuilder($this->createStub(PersonRepository::class));
         $statistics = $builder->buildFromMembers([$root, $ancestor]);
 
         self::assertSame(2, $statistics['members_count']);

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -114,6 +114,7 @@ title:
     edit_union: Edit union
     edit_union_of: Edit union of {name}
     rename_tree: Rename tree {name}
+    person_statistics: Statistics for {name}
     tree_statistics: Statistics for {name}
     tree_of: Tree of {name}
     sources_of: Sources of {name}
@@ -170,6 +171,8 @@ person:
     favorite:
         added: '**{name}** has been successfully added to favorites.'
         removed: '**{name}** has been successfully removed from favorites.'
+    statistics:
+        description: Explore the selected member and their ancestor branch through the same statistics as the whole-tree view.
 tree:
     new:
         success: 'The tree **{name}** has been successfully created.'

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -63,6 +63,7 @@ action:
     create: Create
     delete: Delete
     edit: Edit
+    statistics: Statistics
     login: Login
     register: Register
     logout: Logout
@@ -70,6 +71,7 @@ action:
     rename: Rename
     save: Save
     see_tree: See tree
+    show_tree_members: Show tree members
     show: Show
     update: Update
     add_favorite: Add to favorites
@@ -112,6 +114,7 @@ title:
     edit_union: Edit union
     edit_union_of: Edit union of {name}
     rename_tree: Rename tree {name}
+    tree_statistics: Statistics for {name}
     tree_of: Tree of {name}
     sources_of: Sources of {name}
     life_line_of: Life line of {name}
@@ -178,6 +181,35 @@ tree:
     add_member:
         success: '**{name}** has been successfully added to the tree.'
         error: '**{name}** has not been added to the tree.'
+    statistics:
+        description: Explore ages, oldest known dates, and yearly birth and death trends for this tree.
+        members_count: Members count
+        average_age: Average age
+        min_age: Minimum age
+        max_age: Maximum age
+        people_used_count: >-
+            {count, plural,
+                =1 {# member used}
+                other {# members used}
+            }
+        no_oldest_birth: No birth date available.
+        no_oldest_death: No death date available.
+        no_birth_data: No birth data available.
+        no_death_data: No death data available.
+        summary:
+            women: Women age summary
+            men: Men age summary
+            unknown: Unknown gender age summary
+        oldest_birth:
+            title: Oldest known birth
+        oldest_death:
+            title: Oldest known death
+        births:
+            title: Births by year
+            chart_label: Births
+        deaths:
+            title: Deaths by year
+            chart_label: Deaths
     export:
         preparing_svg: Preparing SVG export...
         svg_ready: SVG export ready.

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -187,6 +187,7 @@ tree:
         average_age: Average age
         min_age: Minimum age
         max_age: Maximum age
+        extended_chart_mode: Extended chart mode
         people_used_count: >-
             {count, plural,
                 =1 {# member used}

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -63,6 +63,7 @@ action:
     create: Créer
     delete: Supprimer
     edit: Modifier
+    statistics: Statistiques
     login: 'Se connecter'
     register: "S'inscrire"
     logout: 'Se déconnecter'
@@ -70,6 +71,7 @@ action:
     rename: Renommer
     save: Enregistrer
     see_tree: Voir l'arbre
+    show_tree_members: Voir les membres de l'arbre
     show: Afficher
     update: Mettre à jour
     add_favorite: 'Ajouter aux favoris'
@@ -112,6 +114,7 @@ title:
     edit_union: Modifier l'union
     edit_union_of: Modifier l'union de {name}
     rename_tree: Renommer l'arbre {name}
+    tree_statistics: Statistiques de {name}
     tree_of: Arbre de {name}
     sources_of: Sources de {name}
     life_line_of: Ligne de vie de {name}
@@ -179,6 +182,35 @@ tree:
     add_member:
         success: "**{name}** a bien été ajouté à l'arbre."
         error: "**{name}** n'a pas été ajouté à l'arbre."
+    statistics:
+        description: Explorez les âges, les dates les plus anciennes connues et les tendances annuelles des naissances et décès de cet arbre.
+        members_count: Nombre de membres
+        average_age: Âge moyen
+        min_age: Âge minimum
+        max_age: Âge maximum
+        people_used_count: >-
+            {count, plural,
+                =1 {# membre utilisé}
+                other {# membres utilisés}
+            }
+        no_oldest_birth: Aucune date de naissance disponible.
+        no_oldest_death: Aucune date de décès disponible.
+        no_birth_data: Aucune donnée de naissance disponible.
+        no_death_data: Aucune donnée de décès disponible.
+        summary:
+            women: Résumé des âges des femmes
+            men: Résumé des âges des hommes
+            unknown: Résumé des âges de genre inconnu
+        oldest_birth:
+            title: Naissance connue la plus ancienne
+        oldest_death:
+            title: Décès connu le plus ancien
+        births:
+            title: Naissances par année
+            chart_label: Naissances
+        deaths:
+            title: Décès par année
+            chart_label: Décès
     export:
         preparing_svg: Préparation de l'export SVG...
         svg_ready: L'export SVG est prêt.

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -188,6 +188,7 @@ tree:
         average_age: Âge moyen
         min_age: Âge minimum
         max_age: Âge maximum
+        extended_chart_mode: Mode de graphique étendu
         people_used_count: >-
             {count, plural,
                 =1 {# membre utilisé}

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -114,6 +114,7 @@ title:
     edit_union: Modifier l'union
     edit_union_of: Modifier l'union de {name}
     rename_tree: Renommer l'arbre {name}
+    person_statistics: Statistiques de {name}
     tree_statistics: Statistiques de {name}
     tree_of: Arbre de {name}
     sources_of: Sources de {name}
@@ -171,6 +172,8 @@ person:
     favorite:
         added: "**{name}** a bien été ajouté aux favoris."
         removed: "**{name}** a bien été enlevé des favoris."
+    statistics:
+        description: Explorez le membre sélectionné et sa branche d'ancêtres avec les mêmes statistiques que la vue d'ensemble de l'arbre.
 tree:
     new:
         success: "L'arbre **{name}** a été créé avec succès."


### PR DESCRIPTION
## Summary
- add a dedicated statistics page for trees with age summaries, oldest known dates, yearly birth/death charts, and chart display toggles
- add an equivalent person statistics page scoped to the selected member and their unique ancestor branch, reusing the same metrics and chart behavior
- optimize person statistics loading by preloading the ancestry graph in one query, and add focused tests for aggregation and ancestor collection
- update the PHPUnit 13 configuration so the focused statistics tests run without XML schema warnings or mock-notice noise

## Testing
- docker compose exec apache php bin/phpunit tests/Service/Tree/TreeStatisticsBuilderTest.php tests/Service/Tree/PersonAncestorBranchMemberCollectorTest.php
- docker compose exec apache composer analyse
- docker compose exec apache composer cs:check
- docker compose exec apache php bin/console lint:twig templates/tree/statistics.html.twig templates/person/statistics.html.twig templates/person/base.html.twig

## Notes
- charts use Symfony UX Chart.js with condensed and extended scrollable modes
- person names shown in statistics cards now link back to the relevant profile
- the focused statistics PHPUnit run is now clean under PHPUnit 13