### PR TITLE
feat(gedcom): add transactional GEDCOM imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,33 @@ Because Font Awesome won't serve icons on a local IP address (`127.0.0.1`), chan
 
 You made modifications to entities? Don't forget to [create and execute](https://symfony.com/doc/current/doctrine.html#migrations-creating-the-database-tables-schema) a migration file.
 
+### GEDCOM import API
+
+Authenticated clients can upload genealogy data with `POST /api/trees/import` as
+`multipart/form-data`. The request requires a `file` field containing a GEDCOM
+5.5 or 7.0 `.ged` file, or a GEDZIP 7.0 `.zip`/`.gdz` archive. `treeId` is optional; when it
+is omitted, the import creates a tree. `treeName` optionally overrides the name
+used for that new tree. API writes require the `X-CSRF-Token` header returned by
+the authentication endpoint.
+
+The response contains the target tree, detected GEDCOM version, counts of
+created and updated people/unions/sources/notes/media, and non-blocking import
+warnings. Invalid syntax, unsupported versions, broken references, unsafe ZIP
+archives, or persistence failures reject the full import without changing the
+tree.
+
+Supported V1 mappings are `INDI`, `FAM`, `NAME`, `SEX`, `BIRT`, `DEAT`, `MARR`,
+`DIV`, `DATE`, `PLAC`, `NOTE`, `SOUR`, and `OBJE`. Exact ISO or day-month-year
+dates also fill the existing date fields; all accepted date expressions are
+preserved verbatim. Unknown top-level tags are returned as warnings.
+
+Imports are identified inside a tree by the uploaded filename. Re-uploading a
+file with the same filename updates matching GEDCOM XREF records; GEDCOM values
+and relationships take precedence. Native records and records absent from the
+new file are retained. GEDZIP handling is limited to local archive entries: no
+external media URI is fetched. Uploads are limited to 50 MiB, 200 ZIP entries,
+and 100 MiB after decompression.
+
 ## I want to contribute
 
 Thank you, any help is appreciated. Go to issues tab and find one you like without a code branch refered. Then, feel free to fork this repository and start a new pull request.

--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -4,6 +4,7 @@ api_platform:
     formats:
         jsonld: ['application/ld+json']
         json: ['application/json']
+        multipart: ['multipart/form-data']
     swagger:
         api_keys:
             JWT:

--- a/migrations/Version20260820171430.php
+++ b/migrations/Version20260820171430.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260820171430 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE gedcom_identifier (id INT AUTO_INCREMENT NOT NULL, record_type VARCHAR(16) NOT NULL, external_id VARCHAR(255) NOT NULL, import_id INT NOT NULL, person_id INT DEFAULT NULL, union_id INT DEFAULT NULL, INDEX IDX_1E2A068B6A263D9 (import_id), INDEX IDX_1E2A068217BBB47 (person_id), INDEX IDX_1E2A0682C7B5539 (union_id), UNIQUE INDEX uniq_gedcom_identifier (import_id, record_type, external_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('CREATE TABLE gedcom_import (id INT AUTO_INCREMENT NOT NULL, filename VARCHAR(255) NOT NULL, format VARCHAR(16) NOT NULL, imported_at DATETIME NOT NULL, tree_id INT NOT NULL, INDEX IDX_27FDD6AA78B64A2 (tree_id), UNIQUE INDEX uniq_gedcom_import_tree_filename (tree_id, filename), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('CREATE TABLE gedcom_metadata (id INT AUTO_INCREMENT NOT NULL, type VARCHAR(16) NOT NULL, external_id VARCHAR(255) DEFAULT NULL, payload JSON NOT NULL, import_id INT NOT NULL, person_id INT DEFAULT NULL, union_id INT DEFAULT NULL, INDEX IDX_F7FC2E8EB6A263D9 (import_id), INDEX IDX_F7FC2E8E217BBB47 (person_id), INDEX IDX_F7FC2E8E2C7B5539 (union_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('ALTER TABLE gedcom_identifier ADD CONSTRAINT FK_1E2A068B6A263D9 FOREIGN KEY (import_id) REFERENCES gedcom_import (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE gedcom_identifier ADD CONSTRAINT FK_1E2A068217BBB47 FOREIGN KEY (person_id) REFERENCES person (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE gedcom_identifier ADD CONSTRAINT FK_1E2A0682C7B5539 FOREIGN KEY (union_id) REFERENCES `union` (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE gedcom_import ADD CONSTRAINT FK_27FDD6AA78B64A2 FOREIGN KEY (tree_id) REFERENCES tree (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE gedcom_metadata ADD CONSTRAINT FK_F7FC2E8EB6A263D9 FOREIGN KEY (import_id) REFERENCES gedcom_import (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE gedcom_metadata ADD CONSTRAINT FK_F7FC2E8E217BBB47 FOREIGN KEY (person_id) REFERENCES person (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE gedcom_metadata ADD CONSTRAINT FK_F7FC2E8E2C7B5539 FOREIGN KEY (union_id) REFERENCES `union` (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE person ADD birth_gedcom_date VARCHAR(255) DEFAULT NULL, ADD death_gedcom_date VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE `union` ADD starts_at_gedcom_date VARCHAR(255) DEFAULT NULL, ADD ends_at_gedcom_date VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE gedcom_identifier DROP FOREIGN KEY FK_1E2A068B6A263D9');
+        $this->addSql('ALTER TABLE gedcom_identifier DROP FOREIGN KEY FK_1E2A068217BBB47');
+        $this->addSql('ALTER TABLE gedcom_identifier DROP FOREIGN KEY FK_1E2A0682C7B5539');
+        $this->addSql('ALTER TABLE gedcom_import DROP FOREIGN KEY FK_27FDD6AA78B64A2');
+        $this->addSql('ALTER TABLE gedcom_metadata DROP FOREIGN KEY FK_F7FC2E8EB6A263D9');
+        $this->addSql('ALTER TABLE gedcom_metadata DROP FOREIGN KEY FK_F7FC2E8E217BBB47');
+        $this->addSql('ALTER TABLE gedcom_metadata DROP FOREIGN KEY FK_F7FC2E8E2C7B5539');
+        $this->addSql('DROP TABLE gedcom_identifier');
+        $this->addSql('DROP TABLE gedcom_import');
+        $this->addSql('DROP TABLE gedcom_metadata');
+        $this->addSql('ALTER TABLE person DROP birth_gedcom_date, DROP death_gedcom_date');
+        $this->addSql('ALTER TABLE `union` DROP starts_at_gedcom_date, DROP ends_at_gedcom_date');
+    }
+}

--- a/src/ApiResource/TreeCollection.php
+++ b/src/ApiResource/TreeCollection.php
@@ -13,12 +13,15 @@ use ApiPlatform\Metadata\Put;
 use App\Dto\CreateTreeInput;
 use App\Dto\PersonOutput;
 use App\Dto\TreeOutput;
+use App\Dto\ImportGedcomInput;
+use App\Dto\GedcomImportOutput;
 use App\State\CreateTreeProcessor;
 use App\State\DeleteTreeProcessor;
 use App\State\TreePeopleProvider;
 use App\State\TreeProvider;
 use App\State\TreesProvider;
 use App\State\UpdateTreeProcessor;
+use App\State\ImportGedcomProcessor;
 
 #[ApiResource(
     operations: [
@@ -46,6 +49,15 @@ use App\State\UpdateTreeProcessor;
             input: CreateTreeInput::class,
             output: TreeOutput::class,
             processor: CreateTreeProcessor::class,
+        ),
+        new Post(
+            uriTemplate: '/trees/import',
+            inputFormats: ['multipart' => ['multipart/form-data']],
+            security: "is_granted('ROLE_USER')",
+            input: ImportGedcomInput::class,
+            output: GedcomImportOutput::class,
+            deserialize: false,
+            processor: ImportGedcomProcessor::class,
         ),
         new Put(
             uriTemplate: '/trees/{id}',

--- a/src/Application/Gedcom/ImportGedcom.php
+++ b/src/Application/Gedcom/ImportGedcom.php
@@ -1,0 +1,368 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Gedcom;
+
+use App\Dto\GedcomImportOutput;
+use App\Dto\GedcomImportWarningOutput;
+use App\Dto\TreeOutput;
+use App\Entity\GedcomIdentifier;
+use App\Entity\GedcomImport;
+use App\Entity\GedcomMetadata;
+use App\Entity\Person;
+use App\Entity\Tree;
+use App\Entity\Union;
+use App\Entity\User;
+use App\Gedcom\GedcomDocument;
+use App\Gedcom\GedcomImportException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class ImportGedcom
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        #[Autowire('%kernel.project_dir%/public/pictures/gedcom')]
+        private string $mediaDirectory,
+    ) {}
+
+    public function __invoke(GedcomDocument $document, User $owner, string $filename, ?Tree $targetTree, ?string $treeName): GedcomImportOutput
+    {
+        $this->validateReferences($document);
+        $created = $this->emptyCounters();
+        $updated = $this->emptyCounters();
+        $writtenMedia = [];
+        $this->entityManager->beginTransaction();
+        try {
+            $tree = $targetTree ?? new Tree()
+                ->setUser($owner)
+                ->setName($this->treeName($treeName, $filename))
+                ->setCreatedAt(new \DateTimeImmutable());
+            if (!$targetTree instanceof \App\Entity\Tree) {
+                $this->entityManager->persist($tree);
+            }
+
+            $import = $this->entityManager->getRepository(GedcomImport::class)->findOneBy(['tree' => $tree, 'filename' => $filename]);
+            $isReimport = $import instanceof GedcomImport;
+            if (!$import instanceof GedcomImport) {
+                $import = new GedcomImport($filename, $document->format)->setTree($tree);
+                $this->entityManager->persist($import);
+            } else {
+                $import->setFormat($document->format);
+                $this->entityManager->createQuery('DELETE FROM App\\Entity\\GedcomMetadata metadata WHERE metadata.import = :import')
+                    ->setParameter('import', $import)->execute();
+            }
+
+            $this->entityManager->flush();
+
+            $identifiers = $this->identifiersFor($import);
+            $people = [];
+            foreach ($document->records as $record) {
+                if ('INDI' !== $record['tag']) {
+                    continue;
+                }
+
+                $xref = $this->xref($record);
+                $identifier = $identifiers['INDI:' . $xref] ?? null;
+                $person = $identifier?->getPerson();
+                if (!$person instanceof Person) {
+                    $person = new Person();
+                    $person->setTree($tree);
+                    $identifier = new GedcomIdentifier($import, 'INDI', $xref)->setPerson($person);
+                    $this->entityManager->persist($person);
+                    $this->entityManager->persist($identifier);
+                    ++$created['people'];
+                } else {
+                    ++$updated['people'];
+                }
+
+                $this->applyPerson($person, $record);
+                $people[$xref] = $person;
+                $identifiers['INDI:' . $xref] = $identifier;
+            }
+
+            foreach ($document->records as $record) {
+                if ('FAM' !== $record['tag']) {
+                    continue;
+                }
+
+                $xref = $this->xref($record);
+                $identifier = $identifiers['FAM:' . $xref] ?? null;
+                $union = $identifier?->getUnion();
+                if (!$union instanceof Union) {
+                    $union = new Union();
+                    $identifier = new GedcomIdentifier($import, 'FAM', $xref)->setUnion($union);
+                    $this->entityManager->persist($union);
+                    $this->entityManager->persist($identifier);
+                    ++$created['unions'];
+                } else {
+                    foreach ($union->getPeople()->toArray() as $person) {
+                        $union->removePerson($person);
+                    }
+
+                    foreach ($union->getChildren()->toArray() as $child) {
+                        $union->removeChild($child);
+                    }
+
+                    ++$updated['unions'];
+                }
+
+                $this->applyUnion($union, $record, $people);
+                $identifiers['FAM:' . $xref] = $identifier;
+            }
+
+            if ($isReimport) {
+                $this->persistMetadata($document, $import, $people, $identifiers, $updated);
+            } else {
+                $this->persistMetadata($document, $import, $people, $identifiers, $created);
+            }
+
+            $this->entityManager->flush();
+            $this->publishMedia($document, $import, $writtenMedia);
+            $created['media'] += \count($writtenMedia);
+            $this->entityManager->commit();
+        } catch (\Throwable $exception) {
+            $this->entityManager->rollback();
+            foreach ($writtenMedia as $path) {
+                if (is_file($path)) {
+                    unlink($path);
+                }
+            }
+
+            if ($exception instanceof GedcomImportException) {
+                throw $exception;
+            }
+
+            throw new GedcomImportException('GEDCOM import failed and was rolled back.', $exception->getCode(), previous: $exception);
+        }
+
+        return new GedcomImportOutput(
+            new TreeOutput($tree->getId() ?? 0, $tree->getName() ?? '', $tree->getCreatedAt() ?? new \DateTimeImmutable('@0')),
+            $document->format,
+            $created,
+            $updated,
+            array_map(static fn(array $warning): GedcomImportWarningOutput => new GedcomImportWarningOutput($warning['code'], $warning['line'], $warning['tag'], $warning['message']), $document->warnings),
+        );
+    }
+
+    /** @return array<string, GedcomIdentifier> */
+    private function identifiersFor(GedcomImport $import): array
+    {
+        $identifiers = $this->entityManager->getRepository(GedcomIdentifier::class)->findBy(['import' => $import]);
+
+        return array_reduce($identifiers, static function (array $result, GedcomIdentifier $identifier): array {
+            $result[$identifier->getRecordType() . ':' . $identifier->getExternalId()] = $identifier;
+            return $result;
+        }, []);
+    }
+
+    /** @param array<string, Person> $people
+     * @param non-empty-array<string, mixed> $record */
+    private function applyUnion(Union $union, array $record, array $people): void
+    {
+        $marriage = $this->child($record, 'MARR');
+        $union->setMarried(null !== $marriage);
+        if (\is_array($marriage)) {
+            $date = $this->value($this->child($marriage, 'DATE'));
+            $union->setStartsAtGedcomDate($date)->setStartsAt($this->normalDate($date));
+            $union->setPlace($this->value($this->child($marriage, 'PLAC')));
+        }
+
+        $divorce = $this->child($record, 'DIV');
+        if (\is_array($divorce)) {
+            $date = $this->value($this->child($divorce, 'DATE'));
+            $union->setEndsAtGedcomDate($date)->setEndsAt($this->normalDate($date));
+        }
+
+        foreach (['HUSB', 'WIFE'] as $tag) {
+            $xref = $this->value($this->child($record, $tag));
+            if (isset($people[$xref])) {
+                $union->addPerson($people[$xref]);
+            }
+        }
+
+        foreach ($this->children($record, 'CHIL') as $child) {
+            $xref = (string) $child['value'];
+            if (isset($people[$xref])) {
+                $union->addChild($people[$xref]);
+            }
+        }
+    }
+
+    /**
+     * @param non-empty-array<string, mixed> $record
+     */
+    private function applyPerson(Person $person, array $record): void
+    {
+        $name = $this->value($this->child($record, 'NAME'));
+        [$firstname, $lastname] = $this->splitName($name);
+        $person->setFirstname($firstname)->setLastname($lastname);
+        $person->setGender(match ($this->value($this->child($record, 'SEX'))) {
+            'M' => Person::MALE,
+            'F' => Person::FEMALE,
+            default => Person::OTHER,
+        });
+        $this->applyLifeEvent($person, $this->child($record, 'BIRT'), true);
+        $this->applyLifeEvent($person, $this->child($record, 'DEAT'), false);
+    }
+
+    private function applyLifeEvent(Person $person, ?array $event, bool $birth): void
+    {
+        $date = \is_array($event) ? $this->value($this->child($event, 'DATE')) : null;
+        $place = \is_array($event) ? $this->value($this->child($event, 'PLAC')) : null;
+        if ($birth) {
+            $person->setBirthGedcomDate($date)->setBirth($this->normalDate($date))->setBirthPlace($place);
+        } else {
+            $person->setDead(\is_array($event))->setDeathGedcomDate($date)->setDeath($this->normalDate($date))->setDeathPlace($place);
+        }
+    }
+
+    /** @param array<string, Person> $people @param array<string, GedcomIdentifier> $identifiers @param array<string, int> $created
+     * @param array<string, \App\Entity\GedcomIdentifier> $identifiers
+     * @param array<string, int> $created */
+    private function persistMetadata(GedcomDocument $document, GedcomImport $import, array $people, array $identifiers, array &$created): void
+    {
+        foreach ($document->records as $record) {
+            $tag = $record['tag'];
+            if (\in_array($tag, ['NOTE', 'SOUR', 'OBJE'], true)) {
+                $type = ['NOTE' => 'note', 'SOUR' => 'source', 'OBJE' => 'media'][$tag];
+                $this->entityManager->persist(new GedcomMetadata($import, $type, $record['xref'] ?? null, ['value' => $record['value'], 'line' => $record['line']]));
+                ++$created[$type === 'note' ? 'notes' : ($type === 'source' ? 'sources' : 'media')];
+            }
+
+            $owner = 'INDI' === $tag ? ($people[$record['xref'] ?? ''] ?? null) : (($identifiers['FAM:' . ($record['xref'] ?? '')] ?? null)?->getUnion());
+            if (!$owner instanceof Person && !$owner instanceof Union) {
+                continue;
+            }
+
+            foreach (['NOTE' => 'note', 'SOUR' => 'citation', 'OBJE' => 'media'] as $metadataTag => $type) {
+                foreach ($this->children($record, $metadataTag) as $metadata) {
+                    $entity = new GedcomMetadata($import, $type, null, ['value' => $metadata['value'], 'line' => $metadata['line']]);
+                    $owner instanceof Person ? $entity->setPerson($owner) : $entity->setUnion($owner);
+                    $this->entityManager->persist($entity);
+                    ++$created[$type === 'note' ? 'notes' : ($type === 'citation' ? 'sources' : 'media')];
+                }
+            }
+        }
+    }
+
+    /** @param list<string> $written */
+    private function publishMedia(GedcomDocument $document, GedcomImport $import, array &$written): void
+    {
+        if ([] === $document->media) {
+            return;
+        }
+
+        $directory = $this->mediaDirectory . '/' . $import->getId();
+        if (!is_dir($directory) && !mkdir($directory, 0o775, true) && !is_dir($directory)) {
+            throw new GedcomImportException('GEDZIP media directory cannot be created.');
+        }
+
+        foreach ($document->media as $media) {
+            $name = basename($media['name']);
+            $path = $directory . '/' . sha1($media['name']) . '-' . $name;
+            if (false === file_put_contents($path, $media['content'])) {
+                throw new GedcomImportException('GEDZIP media file cannot be stored.');
+            }
+
+            $written[] = $path;
+            $this->entityManager->persist(new GedcomMetadata($import, 'media_file', $media['name'], ['path' => 'pictures/gedcom/' . $import->getId() . '/' . basename($path)]));
+        }
+
+        $this->entityManager->flush();
+    }
+
+    private function validateReferences(GedcomDocument $document): void
+    {
+        $ids = [];
+        foreach ($document->records as $record) {
+            if (isset($record['xref'])) {
+                $ids[$record['xref']] = true;
+            }
+        }
+
+        $visit = static function (array $node) use (&$visit, $ids): void {
+            if (\is_string($node['value'] ?? null) && preg_match('/^@[^@\s]+@$/', $node['value']) && !isset($ids[$node['value']])) {
+                throw new GedcomImportException(\sprintf('Unknown GEDCOM reference %s at line %d.', $node['value'], $node['line']));
+            }
+
+            foreach ($node['children'] ?? [] as $child) {
+                $visit($child);
+            }
+        };
+        foreach ($document->records as $record) {
+            $visit($record);
+        }
+    }
+
+    /** @param array<string, mixed> $node @return array<string, mixed>|null */
+    private function child(array $node, string $tag): ?array
+    {
+        foreach ($node['children'] ?? [] as $child) {
+            if ($tag === $child['tag']) {
+                return $child;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<string, mixed> $node @return list<array<string, mixed>> */
+    private function children(array $node, string $tag): array
+    {
+        return array_values(array_filter($node['children'] ?? [], static fn(array $child): bool => $tag === $child['tag']));
+    }
+
+    private function value(?array $node): ?string
+    {
+        return \is_array($node) && '' !== $node['value'] ? (string) $node['value'] : null;
+    }
+
+    /**
+     * @param non-empty-array<string, mixed> $record
+     */
+    private function xref(array $record): string
+    {
+        return isset($record['xref']) && '' !== $record['xref'] ? (string) $record['xref'] : throw new GedcomImportException(\sprintf('%s record at line %d has no identifier.', $record['tag'], $record['line']));
+    }
+
+    private function normalDate(?string $date): ?\DateTimeImmutable
+    {
+        if (null === $date) {
+            return null;
+        }
+
+        foreach (['!d M Y', '!Y-m-d'] as $format) {
+            $parsed = \DateTimeImmutable::createFromFormat($format, strtoupper($date));
+            $errors = \DateTimeImmutable::getLastErrors();
+            if ($parsed instanceof \DateTimeImmutable && (false === $errors || (0 === $errors['warning_count'] && 0 === $errors['error_count']))) {
+                return $parsed;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return array{string, string|null} */
+    private function splitName(?string $name): array
+    {
+        $name = trim((string) $name);
+        if (preg_match('/^(.*?)\s*\/([^\/]+)\//', $name, $matches)) {
+            return [trim($matches[1]), trim($matches[2])];
+        }
+
+        return [$name, null];
+    }
+
+    private function treeName(?string $requested, string $filename): string
+    {
+        return trim((string) $requested) ?: mb_substr(pathinfo($filename, PATHINFO_FILENAME), 0, 30);
+    }
+
+    /** @return array<string, int> */
+    private function emptyCounters(): array
+    {
+        return ['people' => 0, 'unions' => 0, 'sources' => 0, 'notes' => 0, 'media' => 0];
+    }
+}

--- a/src/Dto/GedcomImportOutput.php
+++ b/src/Dto/GedcomImportOutput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+final readonly class GedcomImportOutput
+{
+    /** @param list<GedcomImportWarningOutput> $warnings */
+    public function __construct(
+        public TreeOutput $tree,
+        public string $format,
+        public array $created,
+        public array $updated,
+        public array $warnings,
+    ) {}
+}

--- a/src/Dto/GedcomImportWarningOutput.php
+++ b/src/Dto/GedcomImportWarningOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+final readonly class GedcomImportWarningOutput
+{
+    public function __construct(
+        public string $code,
+        public ?int $line,
+        public ?string $tag,
+        public string $message,
+    ) {}
+}

--- a/src/Dto/ImportGedcomInput.php
+++ b/src/Dto/ImportGedcomInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+final class ImportGedcomInput
+{
+    public ?UploadedFile $file = null;
+
+    public ?int $treeId = null;
+
+    public ?string $treeName = null;
+}

--- a/src/Entity/GedcomIdentifier.php
+++ b/src/Entity/GedcomIdentifier.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'gedcom_identifier')]
+#[ORM\UniqueConstraint(name: 'uniq_gedcom_identifier', columns: ['import_id', 'record_type', 'external_id'])]
+class GedcomIdentifier
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
+    private ?Person $person = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
+    private ?Union $union = null;
+
+    public function __construct(
+        #[ORM\ManyToOne]
+        #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+        private ?GedcomImport $import,
+        #[ORM\Column(length: 16)]
+        private string $recordType,
+        #[ORM\Column(length: 255)]
+        private string $externalId
+    ) {}
+
+    public function getRecordType(): string
+    {
+        return $this->recordType;
+    }
+
+    public function getImport(): ?GedcomImport
+    {
+        return $this->import;
+    }
+
+    public function getExternalId(): string
+    {
+        return $this->externalId;
+    }
+
+    public function getPerson(): ?Person
+    {
+        return $this->person;
+    }
+
+    public function setPerson(Person $person): static
+    {
+        $this->person = $person;
+        return $this;
+    }
+
+    public function getUnion(): ?Union
+    {
+        return $this->union;
+    }
+
+    public function setUnion(Union $union): static
+    {
+        $this->union = $union;
+        return $this;
+    }
+}

--- a/src/Entity/GedcomImport.php
+++ b/src/Entity/GedcomImport.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'gedcom_import')]
+#[ORM\UniqueConstraint(name: 'uniq_gedcom_import_tree_filename', columns: ['tree_id', 'filename'])]
+class GedcomImport
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?Tree $tree = null;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $importedAt;
+
+    public function __construct(#[ORM\Column(length: 255)]
+        private string $filename, #[ORM\Column(length: 16)]
+        private string $format)
+    {
+        $this->importedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTree(): ?Tree
+    {
+        return $this->tree;
+    }
+
+    public function setTree(Tree $tree): static
+    {
+        $this->tree = $tree;
+        return $this;
+    }
+
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+
+    public function getFormat(): string
+    {
+        return $this->format;
+    }
+
+    public function setFormat(string $format): static
+    {
+        $this->format = $format;
+        $this->importedAt = new \DateTimeImmutable();
+        return $this;
+    }
+}

--- a/src/Entity/GedcomMetadata.php
+++ b/src/Entity/GedcomMetadata.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'gedcom_metadata')]
+class GedcomMetadata
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
+    private ?Person $person = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
+    private ?Union $union = null;
+
+    /** @param array<string, mixed> $payload */
+    public function __construct(
+        #[ORM\ManyToOne]
+        #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+        private ?GedcomImport $import,
+        #[ORM\Column(length: 16)]
+        private string $type,
+        #[ORM\Column(length: 255, nullable: true)]
+        private ?string $externalId,
+        #[ORM\Column(type: Types::JSON)]
+        private array $payload
+    ) {}
+
+    public function setPerson(?Person $person): static
+    {
+        $this->person = $person;
+        return $this;
+    }
+
+    public function setUnion(?Union $union): static
+    {
+        $this->union = $union;
+        return $this;
+    }
+}

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -100,6 +100,12 @@ class Person implements \Stringable
     #[Assert\Length(max: 60)]
     private ?string $deathPlace = null;
 
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $birthGedcomDate = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $deathGedcomDate = null;
+
     #[ORM\OneToMany(targetEntity: Source::class, mappedBy: 'person', orphanRemoval: true)]
     private Collection $sources;
 
@@ -396,6 +402,28 @@ class Person implements \Stringable
     {
         $this->deathPlace = $deathPlace;
 
+        return $this;
+    }
+
+    public function getBirthGedcomDate(): ?string
+    {
+        return $this->birthGedcomDate;
+    }
+
+    public function setBirthGedcomDate(?string $date): static
+    {
+        $this->birthGedcomDate = $date;
+        return $this;
+    }
+
+    public function getDeathGedcomDate(): ?string
+    {
+        return $this->deathGedcomDate;
+    }
+
+    public function setDeathGedcomDate(?string $date): static
+    {
+        $this->deathGedcomDate = $date;
         return $this;
     }
 

--- a/src/Entity/Union.php
+++ b/src/Entity/Union.php
@@ -54,6 +54,12 @@ class Union
     #[ORM\Column(nullable: true)]
     private ?\DateTimeImmutable $endsAt = null;
 
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $startsAtGedcomDate = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $endsAtGedcomDate = null;
+
     #[ORM\Column(options: ['default' => false])]
     private ?bool $endDayUnsure = false;
 
@@ -235,6 +241,28 @@ class Union
     {
         $this->endsAt = $endsAt;
 
+        return $this;
+    }
+
+    public function getStartsAtGedcomDate(): ?string
+    {
+        return $this->startsAtGedcomDate;
+    }
+
+    public function setStartsAtGedcomDate(?string $date): static
+    {
+        $this->startsAtGedcomDate = $date;
+        return $this;
+    }
+
+    public function getEndsAtGedcomDate(): ?string
+    {
+        return $this->endsAtGedcomDate;
+    }
+
+    public function setEndsAtGedcomDate(?string $date): static
+    {
+        $this->endsAtGedcomDate = $date;
         return $this;
     }
 

--- a/src/Gedcom/GedcomDocument.php
+++ b/src/Gedcom/GedcomDocument.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Gedcom;
+
+final readonly class GedcomDocument
+{
+    /**
+     * @param list<array<string, mixed>> $records
+     * @param list<array{name: string, content: string}> $media
+     * @param list<array{code: string, line: int|null, tag: string|null, message: string}> $warnings
+     */
+    public function __construct(
+        public string $format,
+        public array $records,
+        public array $media,
+        public array $warnings,
+    ) {}
+}

--- a/src/Gedcom/GedcomImportException.php
+++ b/src/Gedcom/GedcomImportException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Gedcom;
+
+final class GedcomImportException extends \RuntimeException {}

--- a/src/Gedcom/GedcomParser.php
+++ b/src/Gedcom/GedcomParser.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Gedcom;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+final class GedcomParser
+{
+    private const int MAX_UPLOAD_BYTES = 52_428_800;
+
+    private const int MAX_ARCHIVE_ENTRIES = 200;
+
+    private const int MAX_UNCOMPRESSED_BYTES = 104_857_600;
+
+    public function parse(UploadedFile $file): GedcomDocument
+    {
+        if (!$file->isValid() || ($file->getSize() ?? 0) > self::MAX_UPLOAD_BYTES) {
+            throw new GedcomImportException('The uploaded GEDCOM file is invalid or exceeds the 50 MiB limit.');
+        }
+
+        $filename = $file->getClientOriginalName();
+        if (str_ends_with(mb_strtolower($filename), '.zip') || str_ends_with(mb_strtolower($filename), '.gdz')) {
+            return $this->parseGedzip($file);
+        }
+
+        $content = file_get_contents($file->getPathname());
+        if (false === $content) {
+            throw new GedcomImportException('The uploaded GEDCOM file cannot be read.');
+        }
+
+        return $this->parseContent($content, []);
+    }
+
+    private function parseGedzip(UploadedFile $file): GedcomDocument
+    {
+        if (!class_exists(\ZipArchive::class)) {
+            throw new GedcomImportException('GEDZIP imports require the PHP zip extension.');
+        }
+
+        $zip = new \ZipArchive();
+        if (true !== $zip->open($file->getPathname())) {
+            throw new GedcomImportException('The uploaded GEDZIP archive cannot be opened.');
+        }
+
+        try {
+            if ($zip->numFiles > self::MAX_ARCHIVE_ENTRIES) {
+                throw new GedcomImportException('The GEDZIP archive has too many entries.');
+            }
+
+            $uncompressedSize = 0;
+            $media = [];
+            $gedcom = null;
+            for ($index = 0; $index < $zip->numFiles; ++$index) {
+                $stat = $zip->statIndex($index);
+                if (false === $stat || !isset($stat['name'], $stat['size'])) {
+                    throw new GedcomImportException('The GEDZIP archive contains an invalid entry.');
+                }
+
+                $name = $stat['name'];
+                $uncompressedSize += $stat['size'];
+                if ($uncompressedSize > self::MAX_UNCOMPRESSED_BYTES || str_contains($name, '..') || str_starts_with($name, '/')) {
+                    throw new GedcomImportException('The GEDZIP archive violates safety limits.');
+                }
+
+                $contents = $zip->getFromIndex($index);
+                if (false === $contents) {
+                    throw new GedcomImportException('A GEDZIP archive entry cannot be read.');
+                }
+
+                if ('gedcom.ged' === $name) {
+                    $gedcom = $contents;
+                } elseif (!str_ends_with($name, '/')) {
+                    $media[] = ['name' => $name, 'content' => $contents];
+                }
+            }
+
+            if (!\is_string($gedcom)) {
+                throw new GedcomImportException('A GEDZIP archive must contain gedcom.ged.');
+            }
+
+            return $this->parseContent($gedcom, $media);
+        } finally {
+            $zip->close();
+        }
+    }
+
+    /** @param list<array{name: string, content: string}> $media */
+    private function parseContent(string $content, array $media): GedcomDocument
+    {
+        $content = preg_replace('/^\xEF\xBB\xBF/', '', $content) ?? $content;
+        $roots = [];
+        $stack = [];
+        foreach (preg_split('/\r\n|\r|\n/', $content) ?: [] as $offset => $line) {
+            if ('' === trim($line)) {
+                continue;
+            }
+
+            if (!preg_match('/^(\d+)\s+(?:(@[^@\s]+@)\s+)?(\w+)(?:\s+(.*))?$/', $line, $matches)) {
+                throw new GedcomImportException(\sprintf('Malformed GEDCOM line %d.', $offset + 1));
+            }
+
+            $node = ['level' => (int) $matches[1], 'xref' => $matches[2] ?? null, 'tag' => strtoupper($matches[3]), 'value' => $matches[4] ?? '', 'line' => $offset + 1, 'children' => []];
+            while ([] !== $stack && $stack[array_key_last($stack)]['level'] >= $node['level']) {
+                array_pop($stack);
+            }
+
+            if ([] === $stack) {
+                $roots[] = $node;
+                $stack[] = & $roots[array_key_last($roots)];
+            } else {
+                $parent = & $stack[array_key_last($stack)];
+                $parent['children'][] = $node;
+                $stack[] = & $parent['children'][array_key_last($parent['children'])];
+                unset($parent);
+            }
+
+            unset($node);
+        }
+
+        $header = $roots[0] ?? null;
+        if (!\is_array($header) || 'HEAD' !== $header['tag']) {
+            throw new GedcomImportException('A GEDCOM document must start with a HEAD record.');
+        }
+
+        $version = $this->childValue($this->child($header, 'GEDC') ?? [], 'VERS');
+        $format = match (true) {
+            '5.5' === $version => '5.5',
+            \is_string($version) && preg_match('/^7\.0(?:\.\d+)?$/', $version) => '7.0',
+            default => throw new GedcomImportException(\sprintf('Unsupported GEDCOM version "%s".', $version ?? 'unknown')),
+        };
+        if ([] === $roots || 'TRLR' !== ($roots[array_key_last($roots)]['tag'] ?? null)) {
+            throw new GedcomImportException('A GEDCOM document must end with a TRLR record.');
+        }
+
+        $warnings = [];
+        foreach ($roots as $record) {
+            if (!\in_array($record['tag'], ['HEAD', 'TRLR', 'INDI', 'FAM', 'NOTE', 'SOUR', 'OBJE'], true)) {
+                $warnings[] = ['code' => 'unsupported_tag', 'line' => $record['line'], 'tag' => $record['tag'], 'message' => 'Unsupported GEDCOM record was ignored.'];
+            }
+        }
+
+        return new GedcomDocument($format, $roots, $media, $warnings);
+    }
+
+    /** @param array<string, mixed> $node @return array<string, mixed>|null */
+    private function child(array $node, string $tag): ?array
+    {
+        foreach ($node['children'] ?? [] as $child) {
+            if ($tag === $child['tag']) {
+                return $child;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<string, mixed> $node */
+    private function childValue(array $node, string $tag): ?string
+    {
+        $child = $this->child($node, $tag);
+
+        return \is_array($child) ? (string) $child['value'] : null;
+    }
+}

--- a/src/State/ImportGedcomProcessor.php
+++ b/src/State/ImportGedcomProcessor.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Application\Gedcom\ImportGedcom;
+use App\Dto\GedcomImportOutput;
+use App\Dto\ImportGedcomInput;
+use App\Entity\Tree;
+use App\Entity\User;
+use App\Gedcom\GedcomImportException;
+use App\Gedcom\GedcomParser;
+use App\Repository\TreeRepository;
+use App\Security\Voter\TreeVoter;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/** @implements ProcessorInterface<ImportGedcomInput, GedcomImportOutput> */
+final readonly class ImportGedcomProcessor implements ProcessorInterface
+{
+    public function __construct(private Security $security, private TreeRepository $trees, private GedcomParser $parser, private ImportGedcom $importGedcom, private RequestStack $requestStack) {}
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): GedcomImportOutput
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        $file = $request?->files->get('file');
+        if (!$file instanceof \Symfony\Component\HttpFoundation\File\UploadedFile) {
+            throw new BadRequestHttpException('A GEDCOM file is required.');
+        }
+
+        $treeId = $request?->request->get('treeId');
+        $treeName = $request?->request->get('treeName');
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $tree = null;
+        if (null !== $treeId && '' !== $treeId) {
+            $tree = $this->trees->find((int) $treeId);
+            if (!$tree instanceof Tree) {
+                throw new NotFoundHttpException('Tree not found.');
+            }
+
+            if (!$this->security->isGranted(TreeVoter::EDIT, $tree)) {
+                throw new AccessDeniedHttpException();
+            }
+        }
+
+        try {
+            return ($this->importGedcom)($this->parser->parse($file), $user, $file->getClientOriginalName(), $tree, \is_string($treeName) ? $treeName : null);
+        } catch (GedcomImportException $exception) {
+            throw new UnprocessableEntityHttpException($exception->getMessage(), $exception);
+        }
+    }
+}

--- a/tests/Api/GedcomImportTest.php
+++ b/tests/Api/GedcomImportTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use App\Entity\GedcomMetadata;
+use App\Entity\Person;
+use App\Entity\Tree;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+final class GedcomImportTest extends WebTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    private KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = self::createClient([], ['HTTPS' => 'on']);
+        $this->entityManager = self::getContainer()->get('doctrine')->getManager();
+        new SchemaTool($this->entityManager)->updateSchema($this->entityManager->getMetadataFactory()->getAllMetadata());
+        $this->cleanup();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanup();
+        parent::tearDown();
+    }
+
+    public function testImportsFixtureIntoNewTreeAndReimportsByFilename(): void
+    {
+        $this->createUser();
+        $this->login();
+        $this->upload($this->fixture('family-5.5.ged'), ['treeName' => 'Imported family']);
+
+        self::assertResponseStatusCodeSame(201);
+        $response = json_decode((string) $this->client->getResponse()->getContent(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame('5.5', $response['format']);
+        self::assertSame(2, $response['created']['people']);
+        self::assertSame(1, $response['created']['unions']);
+        self::assertSame('Imported family', $response['tree']['name']);
+
+        $tree = $this->entityManager->getRepository(Tree::class)->find($response['tree']['id']);
+        self::assertInstanceOf(Tree::class, $tree);
+        self::assertCount(2, $this->entityManager->getRepository(Person::class)->findBy(['tree' => $tree]));
+        self::assertGreaterThanOrEqual(2, \count($this->entityManager->getRepository(GedcomMetadata::class)->findAll()));
+
+        $path = tempnam(sys_get_temp_dir(), 'gedcom-reimport-');
+        self::assertNotFalse($path);
+        file_put_contents($path, str_replace('John /Doe/', 'Johnny /Doe/', (string) file_get_contents(__DIR__ . '/../Fixtures/Gedcom/family-5.5.ged')));
+        $this->upload(new UploadedFile($path, 'family-5.5.ged', 'application/octet-stream', null, true), ['treeId' => (string) $tree->getId()]);
+
+        self::assertResponseStatusCodeSame(201);
+        $updated = json_decode((string) $this->client->getResponse()->getContent(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame(2, $updated['updated']['people']);
+        $this->entityManager->clear();
+        $tree = $this->entityManager->getRepository(Tree::class)->find($tree->getId());
+        self::assertInstanceOf(Tree::class, $tree);
+        self::assertCount(2, $this->entityManager->getRepository(Person::class)->findBy(['tree' => $tree]));
+        self::assertNotNull($this->entityManager->getRepository(Person::class)->findOneBy(['tree' => $tree, 'firstname' => 'Johnny']));
+    }
+
+    public function testImportRequiresCsrfToken(): void
+    {
+        $this->createUser();
+        $this->client->jsonRequest('POST', '/api/auth', ['email' => 'gedcom@example.com', 'password' => 'password']);
+        self::assertResponseIsSuccessful();
+
+        $this->upload($this->fixture('family-7.0.ged'));
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    /**
+     * @param array<string, string>|array<string, decimal-int-string>|string[] $parameters
+     */
+    private function upload(UploadedFile $file, array $parameters = []): void
+    {
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/trees/import', $parameters, ['file' => $file], [
+            'HTTP_ACCEPT' => 'application/json',
+            'CONTENT_TYPE' => 'multipart/form-data',
+        ]);
+    }
+
+    private function fixture(string $name): UploadedFile
+    {
+        return new UploadedFile(__DIR__ . '/../Fixtures/Gedcom/' . $name, $name, 'application/octet-stream', null, true);
+    }
+
+    private function createUser(): void
+    {
+        $user = new User()->setEmail('gedcom@example.com')->setFirstname('Gedcom')->setLastname('User')->setIsVerified(true);
+        $user->setPassword(self::getContainer()->get(UserPasswordHasherInterface::class)->hashPassword($user, 'password'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+    }
+
+    private function login(): void
+    {
+        $this->client->jsonRequest('POST', '/api/auth', ['email' => 'gedcom@example.com', 'password' => 'password']);
+        self::assertResponseIsSuccessful();
+        $csrf = $this->responseCookie('csrf_token');
+        self::assertNotNull($csrf);
+        $this->client->setServerParameter('HTTP_X_CSRF_TOKEN', $csrf->getValue());
+    }
+
+    private function responseCookie(string $name): ?Cookie
+    {
+        foreach ($this->client->getResponse()->headers->getCookies() as $cookie) {
+            if ($name === $cookie->getName()) {
+                return $cookie;
+            }
+        }
+
+        return null;
+    }
+
+    private function cleanup(): void
+    {
+        $this->entityManager->createQuery('DELETE FROM App\\Entity\\User user WHERE user.email = :email')->setParameter('email', 'gedcom@example.com')->execute();
+    }
+}

--- a/tests/Fixtures/Gedcom/family-5.5.ged
+++ b/tests/Fixtures/Gedcom/family-5.5.ged
@@ -1,0 +1,24 @@
+0 HEAD
+1 SOUR Genealogist fixtures
+1 GEDC
+2 VERS 5.5
+0 @I1@ INDI
+1 NAME John /Doe/
+1 SEX M
+1 BIRT
+2 DATE 1 JAN 1900
+2 PLAC Paris
+1 NOTE @N1@
+1 SOUR @S1@
+0 @I2@ INDI
+1 NAME Jane /Doe/
+1 SEX F
+0 @F1@ FAM
+1 HUSB @I1@
+1 WIFE @I2@
+1 MARR
+2 DATE 2 FEB 1920
+2 PLAC Lyon
+0 @N1@ NOTE Family note
+0 @S1@ SOUR Parish register
+0 TRLR

--- a/tests/Fixtures/Gedcom/family-7.0.ged
+++ b/tests/Fixtures/Gedcom/family-7.0.ged
@@ -1,0 +1,10 @@
+0 HEAD
+1 GEDC
+2 VERS 7.0
+0 @I1@ INDI
+1 NAME Ada /Lovelace/
+1 SEX F
+1 BIRT
+2 DATE ABT 1815
+2 PLAC London
+0 TRLR

--- a/tests/Gedcom/GedcomParserTest.php
+++ b/tests/Gedcom/GedcomParserTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Gedcom;
+
+use App\Gedcom\GedcomImportException;
+use App\Gedcom\GedcomParser;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+final class GedcomParserTest extends TestCase
+{
+    public function testParsesGedcom55And70Fixtures(): void
+    {
+        $parser = new GedcomParser();
+
+        self::assertSame('5.5', $parser->parse($this->file('family-5.5.ged'))->format);
+        self::assertSame('7.0', $parser->parse($this->file('family-7.0.ged'))->format);
+    }
+
+    public function testRejectsUnknownVersion(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'gedcom-');
+        self::assertNotFalse($path);
+        file_put_contents($path, "0 HEAD\n1 GEDC\n2 VERS 5.5.1\n0 TRLR\n");
+
+        $this->expectException(GedcomImportException::class);
+        new GedcomParser()->parse(new UploadedFile($path, 'unsupported.ged', null, null, true));
+    }
+
+    public function testParsesGedzipWithEmbeddedMedia(): void
+    {
+        if (!class_exists(\ZipArchive::class)) {
+            self::markTestSkipped('The zip extension is unavailable.');
+        }
+
+        $path = tempnam(sys_get_temp_dir(), 'gedzip-');
+        self::assertNotFalse($path);
+        $zip = new \ZipArchive();
+        self::assertTrue($zip->open($path, \ZipArchive::CREATE | \ZipArchive::OVERWRITE));
+        $zip->addFromString('gedcom.ged', (string) file_get_contents(__DIR__ . '/../Fixtures/Gedcom/family-7.0.ged'));
+        $zip->addFromString('media/portrait.txt', 'portrait');
+        $zip->close();
+
+        $document = new GedcomParser()->parse(new UploadedFile($path, 'family.zip', 'application/zip', null, true));
+
+        self::assertSame('7.0', $document->format);
+        self::assertCount(1, $document->media);
+        self::assertSame('media/portrait.txt', $document->media[0]['name']);
+    }
+
+    private function file(string $name): UploadedFile
+    {
+        return new UploadedFile(__DIR__ . '/../Fixtures/Gedcom/' . $name, $name, 'application/octet-stream', null, true);
+    }
+}


### PR DESCRIPTION
## Summary
- add an authenticated, CSRF-protected GEDCOM 5.5, 7.0, and GEDZIP import endpoint
- preserve import provenance, identifiers, relationships, dates, notes, sources, and media metadata
- document import semantics and add parser/API coverage

## Verification
- `docker compose exec app composer analyse`
- `docker compose exec app composer rector`
- `docker compose exec app composer cs:check`
- `docker compose exec app php bin/phpunit tests/Gedcom/GedcomParserTest.php tests/Api/GedcomImportTest.php`

Fixes #165